### PR TITLE
Adapted for Elixir v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,35 +8,21 @@ An Elixir based DSL for operating the ElasticSearch cluster related stuff, such 
 
 releases:
 
-- `v0.5.0` tested on elastisearch `1.1.1`, elixir `0.13.1`
-- `v0.4` tested on elastisearch `0.90.3`, elixir `0.12.5`
+- `v0.5.0` tested on elastcisearch `1.4.2`, elixir `1.0.2`
+- `v0.5.0` tested on elastcisearch `1.1.1`, elixir `0.13.1`
+- `v0.4` tested on elasticsearch `0.90.3`, elixir `0.12.5`
 
 Walk-through a code
 -------------------
 
-Let's create an `articles` index:
-
-```elixir
-import Tirexs.Bulk
-
-settings = Tirexs.ElasticSearch.Config.new()
-
-Tirexs.Bulk.store [index: "articles", refresh: true], settings do
-  create id: 1, title: "One", tags: ["elixir"], type: "article"
-  create id: 2, title: "Two", tags: ["elixir", "ruby"], type: "article"
-  create id: 3, title: "Three", tags: ["java"], type: "article"
-  create id: 4, title: "Four", tags: ["erlang"], type: "article"
-end
-```
-
-Ability to customize the mapping for specific document type:
+Let's define the mapping for specific document type:
 
 ```elixir
 import Tirexs.Mapping
 
 index = [index: "articles", type: "article"]
 mappings do
-  indexes "id", type: "string", index: "not_analyzed", include_in_all: false
+  indexes "id", type: "long", index: "not_analyzed", include_in_all: false
   indexes "title", type: "string", boost: 2.0, analyzer: "snowball"
   indexes "tags",  type: "string", analyzer: "keyword"
   indexes "content", type: "string", analyzer: "snowball"
@@ -49,10 +35,27 @@ end
 { :ok, status, body } = Tirexs.Mapping.create_resource(index)
 ```
 
+Then let's populate an `articles` index:
+
+```elixir
+import Tirexs.Bulk
+require Tirexs.ElasticSearch
+
+settings = Tirexs.ElasticSearch.config()
+
+Tirexs.Bulk.store [index: "articles", refresh: true], settings do
+  create id: 1, title: "One", tags: ["elixir"], type: "article"
+  create id: 2, title: "Two", tags: ["elixir", "ruby"], type: "article"
+  create id: 3, title: "Three", tags: ["java"], type: "article"
+  create id: 4, title: "Four", tags: ["erlang"], type: "article"
+end
+```
+
 Now, let's go further. We will be searching for articles whose title begins with letter “T”, sorted by title in descending order, filtering them for ones tagged “elixir”, and also retrieving some facets:
 
 ```elixir
 import Tirexs.Search
+require Tirexs.Query
 
 articles = search [index: "articles"] do
   query do
@@ -82,7 +85,7 @@ end
 
 result = Tirexs.Query.create_resource(articles)
 
-Enum.each result.hits, fn(item) ->
+Enum.each Tirexs.Query.result(result, :hits), fn(item) ->
   IO.puts inspect(item)
   #=> [{"_index","articles"},{"_type","article"},{"_id","2"},{"_score",1.0},{"_source",[{"id",2}, {"title","Two"},{"tags",["elixir","r uby"]},{"type","article"}]}]
 end
@@ -90,8 +93,8 @@ end
 
 Let's display the global facets:
 ```elixir
-Enum.each result.facets["global_tags"]["terms"], fn(f) ->
-  IO.puts "#{f["term"]}    #{f["count"]}"
+Enum.each Tirexs.Query.result(result, :facets).global_tags.terms, fn(f) ->
+  IO.puts "#{f.term}    #{f.count}"
 end
 
 #=> elixir  2
@@ -101,8 +104,8 @@ end
 ```
 Now, let's display the facets based on current query (notice that count for articles tagged with 'java' is included, even though it's not returned by our query; count for articles tagged 'erlang' is excluded, since they don't match the current query):
 ```elixir
-Enum.each result.facets["current_tags"]["terms"], fn(f) ->
-  IO.puts "#{f["term"]}    #{f["count"]}"
+Enum.each Tirexs.Query.result(result, :facets).current_tags.terms, fn(f) ->
+  IO.puts "#{f.term}    #{f.count}"
 end
 
 #=> ruby    1

--- a/examples/mapping.exs
+++ b/examples/mapping.exs
@@ -9,10 +9,11 @@
 #   Tirexs.Loader.load Path.expand("examples/mapping.exs")
 #
 import Tirexs.Mapping
+require Tirexs.ElasticSearch
 
 Tirexs.DSL.define [type: "dsl", index: "test_dsl_index"], fn(index, _) ->
 
-  elastic_settings = Tirexs.ElasticSearch.Config.new([user: "new_user"])
+  elastic_settings = Tirexs.ElasticSearch.config(user: "new_user")
 
    mappings do
      indexes "mn_opts_", [type: "nested"] do
@@ -31,7 +32,7 @@ Tirexs.DSL.define [type: "dsl", index: "test_dsl_index"], fn(index, _) ->
    # Below a couple of code which could be useful for debugging
 
    # url  = Tirexs.ElasticSearch.make_url(index[:index], elastic_settings)
-   # json = JSEX.prettify!(Tirexs.Mapping.to_resource_json(index))
+   # json = JSX.prettify!(Tirexs.Mapping.to_resource_json(index))
    # IO.puts "\n # => curl -X PUT -d '#{json}' #{url}"
 
    { index, elastic_settings }

--- a/examples/river/couchdb_river.exs
+++ b/examples/river/couchdb_river.exs
@@ -38,7 +38,7 @@ Tirexs.DSL.define [name: "tets_river_dsl"], fn(river, elastic_settings) ->
 
   # Below a couple of code which could be useful for debugging
   # url  = Tirexs.ElasticSearch.make_url("_river/" <> river[:name] <>"/_meta", elastic_settings)
-  # json = JSEX.prettify!(Tirexs.River.to_resource_json(river))
+  # json = JSX.prettify!(Tirexs.River.to_resource_json(river))
   # IO.puts "\n # => curl -X PUT -d '#{json}' #{url}"
 
   { river, elastic_settings }

--- a/examples/search.exs
+++ b/examples/search.exs
@@ -30,7 +30,7 @@ Tirexs.DSL.define fn(elastic_settings) ->
 
   # Below a couple of code which could be useful for debugging
   # url  = Tirexs.ElasticSearch.make_url(search[:index] <> "/_search", elastic_settings)
-  # json = JSEX.prettify!(Tirexs.Query.to_resource_json(search))
+  # json = JSX.prettify!(Tirexs.Query.to_resource_json(search))
   # IO.puts "\n # => curl -X POST -d '#{json}' #{url}"
 
   { search, elastic_settings }

--- a/lib/tirexs/bulk.ex
+++ b/lib/tirexs/bulk.ex
@@ -52,7 +52,7 @@ defmodule Tirexs.Bulk do
       header = Dict.put([], action, meta)
 
       output = []
-      output =  output ++ [JSEX.encode!(header)]
+      output =  output ++ [JSX.encode!(header)]
       unless action == :delete do
         output =  output ++ [convert_document_to_json(document)]
       end
@@ -80,7 +80,7 @@ defmodule Tirexs.Bulk do
   end
 
   def convert_document_to_json(document) do
-    JSEX.encode!(document)
+    JSX.encode!(document)
   end
 
   def get_type_from_document(document) do

--- a/lib/tirexs/dsl.ex
+++ b/lib/tirexs/dsl.ex
@@ -1,3 +1,5 @@
+require Tirexs.ElasticSearch
+
 defmodule Tirexs.DSL do
   @moduledoc """
   This module represents a main entry point for defining DSL scenarios.
@@ -6,7 +8,7 @@ defmodule Tirexs.DSL do
 
   @doc false
   def define(type, resource) do
-    elastic_settings = Tirexs.ElasticSearch.Config.new()
+    elastic_settings = Tirexs.ElasticSearch.config()
     case resource.(type, elastic_settings) do
       { type, elastic_settings } -> create_resource(type, elastic_settings)
     end
@@ -14,7 +16,7 @@ defmodule Tirexs.DSL do
 
   @doc false
   def define(resource) do
-    elastic_settings = Tirexs.ElasticSearch.Config.new()
+    elastic_settings = Tirexs.ElasticSearch.config()
     case resource.(elastic_settings) do
       { type, elastic_settings } -> create_resource(type, elastic_settings)
     end

--- a/lib/tirexs/dsl/logic.ex
+++ b/lib/tirexs/dsl/logic.ex
@@ -1,4 +1,6 @@
 defmodule Tirexs.DSL.Logic do
+  require Record
+
   @moduledoc """
   Defines a main module which provides a common contract for DSL handlers and common utilities.
   """
@@ -31,12 +33,12 @@ defmodule Tirexs.DSL.Logic do
 
   @doc false
   def to_atom(value) when is_atom(value), do: value
-  def to_atom(value) when is_binary(value), do: binary_to_atom(value)
+  def to_atom(value) when is_binary(value), do: String.to_atom(value)
   def to_atom(value), do: value
 
   @doc false
   def is_dict?(dict) do
-    is_record(dict, Dict) || false
+    Record.is_record(dict, Dict) || false
   end
 
   @doc false

--- a/lib/tirexs/elastic_search.ex
+++ b/lib/tirexs/elastic_search.ex
@@ -1,10 +1,12 @@
+require Record
+
 defmodule Tirexs.ElasticSearch do
 
   @doc """
   This module provides a simple convenience for connection options such as `port`, `uri`, `user`, `pass`
   and functions for doing a `HTTP` request to `ElasticSearch` engine directly.
   """
-  defrecord Config,  [port: 9200, uri: "127.0.0.1", user: nil, pass: nil]
+  Record.defrecord :config, [port: 9200, uri: "127.0.0.1", user: nil, pass: nil]
 
   @doc false
   def get(query_url, config) do
@@ -54,7 +56,7 @@ defmodule Tirexs.ElasticSearch do
   @doc false
   def do_request(url, method, body \\ []) do
     :inets.start()
-    { url, content_type, options } = { String.to_char_list!(url), 'application/json', [{:body_format, :binary}] }
+    { url, content_type, options } = { String.to_char_list(url), 'application/json', [{:body_format, :binary}] }
     case method do
       :get    -> response(:httpc.request(method, {url, []}, [], []))
       :head   -> response(:httpc.request(method, {url, []}, [], []))
@@ -80,13 +82,13 @@ defmodule Tirexs.ElasticSearch do
     end
   end
 
-  def get_body_json(body), do: JSEX.decode!(to_string(body), [{:labels, :atom}])
+  def get_body_json(body), do: JSX.decode!(to_string(body), [{:labels, :atom}])
 
   def make_url(query_url, config) do
-    if config.port == nil || config.port == 80 do
+    if config(config, :port) == nil || config(config, :port) == 80 do
       "http://#{config.uri}/#{query_url}"
     else
-      "http://#{config.uri}:#{config.port}/#{query_url}"
+      "http://#{config(config, :uri)}:#{config(config, :port)}/#{query_url}"
     end
   end
 

--- a/lib/tirexs/elastic_search/settings.ex
+++ b/lib/tirexs/elastic_search/settings.ex
@@ -1,11 +1,14 @@
+require Tirexs.ElasticSearch
+
 defmodule Tirexs.ElasticSearch.Settings do
   @moduledoc false
 
   import Tirexs.ElasticSearch
+  require Tirexs.ElasticSearch
 
   @doc false
   def create_resource(definition) do
-    create_resource(definition, Tirexs.ElasticSearch.Config.new)
+    create_resource(definition, Tirexs.ElasticSearch.config())
   end
 
   @doc false
@@ -16,6 +19,6 @@ defmodule Tirexs.ElasticSearch.Settings do
 
   @doc false
   def to_resource_json(definition) do
-    JSEX.encode! [settings: definition[:settings]]
+    JSX.encode! [settings: definition[:settings]]
   end
 end

--- a/lib/tirexs/logger.ex
+++ b/lib/tirexs/logger.ex
@@ -2,14 +2,14 @@ defmodule Tirexs.Logger do
   @moduledoc false
 
   def to_curl(data) do
-    case JSEX.is_json?(data) do
+    case JSX.is_json?(data) do
       true  -> log(data)
-      false -> log(JSEX.encode!(data))
+      false -> log(JSX.encode!(data))
     end
   end
 
   defp log(json) do
-    :error_logger.info_msg(JSEX.prettify!(json))
+    :error_logger.info_msg(JSX.prettify!(json))
   end
 
 end

--- a/lib/tirexs/manage.ex
+++ b/lib/tirexs/manage.ex
@@ -6,7 +6,7 @@ defmodule Tirexs.Manage do
   end
 
   def delete_by_query(options, settings) do
-    _body = JSEX.encode!(options[:filter] || options[:query] || [])
+    _body = JSX.encode!(options[:filter] || options[:query] || [])
     #To do add DELETE with body
     Tirexs.ElasticSearch.delete(make_url("_query", options), settings)
   end
@@ -24,7 +24,7 @@ defmodule Tirexs.Manage do
   end
 
   def update(options, update_params, settings) do
-    Tirexs.ElasticSearch.post(make_url("_update", options), JSEX.encode!(update_params), settings)
+    Tirexs.ElasticSearch.post(make_url("_update", options), JSX.encode!(update_params), settings)
   end
 
   def create(:warmer, options, settings) do
@@ -33,7 +33,7 @@ defmodule Tirexs.Manage do
     Tirexs.ElasticSearch.put("bear_test/_warmer/warmer_1", settings)
     Enum.each Dict.keys(warmers), fn(key) ->
       url = make_url(to_string(key), options)
-      body = JSEX.encode!(warmers[key][:source])
+      body = JSX.encode!(warmers[key][:source])
       Tirexs.ElasticSearch.put(url, body, settings)
     end
   end
@@ -80,7 +80,7 @@ defmodule Tirexs.Manage do
         options[:query] -> [query: options[:query]]
         true -> []
       end
-    case JSEX.encode!(body) do
+    case JSX.encode!(body) do
       "[]" -> Tirexs.ElasticSearch.get(make_url(url_suffix, options), settings)
       body -> Tirexs.ElasticSearch.post(make_url(url_suffix, options), body, settings)
     end

--- a/lib/tirexs/mapping.ex
+++ b/lib/tirexs/mapping.ex
@@ -1,8 +1,11 @@
+require Tirexs.ElasticSearch
+
 defmodule Tirexs.Mapping do
   @moduledoc false
 
   use Tirexs.DSL.Logic
   import Tirexs.ElasticSearch
+  require Tirexs.ElasticSearch
 
 
   def transpose(block) do
@@ -40,7 +43,7 @@ defmodule Tirexs.Mapping do
 
   @doc false
   def create_resource(definition) do
-    create_resource(definition, Tirexs.ElasticSearch.Config.new)
+    create_resource(definition, Tirexs.ElasticSearch.config())
   end
 
   @doc false
@@ -71,6 +74,6 @@ defmodule Tirexs.Mapping do
   @doc false
   def to_resource_json(definition, type) do
     json_dict = Dict.put([], to_atom(type), definition[:mapping])
-		JSEX.encode!(json_dict)
+		JSX.encode!(json_dict)
   end
 end

--- a/lib/tirexs/percolator.ex
+++ b/lib/tirexs/percolator.ex
@@ -45,7 +45,7 @@ defmodule Tirexs.Percolator do
     definition = Dict.delete(definition, :index)
     definition = Dict.delete(definition, :type)
     definition = Dict.delete(definition, :name)
-    JSEX.encode!(definition)
+    JSX.encode!(definition)
   end
 
   def matches(definition, settings) do

--- a/lib/tirexs/query.ex
+++ b/lib/tirexs/query.ex
@@ -1,4 +1,8 @@
+require Tirexs.ElasticSearch
+
 defmodule Tirexs.Query do
+  require Record
+
   #http://www.elasticsearch.org/guide/reference/query-dsl/
 
   @moduledoc false
@@ -6,7 +10,7 @@ defmodule Tirexs.Query do
   import Tirexs.DSL.Logic
   import Tirexs.Query.Logic
 
-  defrecord Result, [count: 0, max_score: nil, facets: [], hits: [], _scroll_id: nil]
+  Record.defrecord :result, [count: 0, max_score: nil, facets: [], hits: [], _scroll_id: nil]
 
 
   @doc false
@@ -408,7 +412,7 @@ defmodule Tirexs.Query do
 
   @doc false
   def create_resource(definition) do
-    create_resource(definition, Tirexs.ElasticSearch.Config.new)
+    create_resource(definition, Tirexs.ElasticSearch.config())
   end
 
   @doc false
@@ -427,11 +431,11 @@ defmodule Tirexs.Query do
         facets    = result[:facets]
         max_score = result[:hits][:max_score]
         scroll_id = result[:_scroll_id]
-        Result.new(count: count, hits: hits, facets: facets, max_score: max_score, _scroll_id: scroll_id)
+        result(count: count, hits: hits, facets: facets, max_score: max_score, _scroll_id: scroll_id)
       result  -> result
     end
   end
 
   @doc false
-  def to_resource_json(definition), do: JSEX.encode!(definition[:search])
+  def to_resource_json(definition), do: JSX.encode!(definition[:search])
 end

--- a/lib/tirexs/river.ex
+++ b/lib/tirexs/river.ex
@@ -1,7 +1,10 @@
+require Tirexs.ElasticSearch
+
 defmodule Tirexs.River do
   @moduledoc false
 
   import Tirexs.ElasticSearch
+  require Tirexs.ElasticSearch
 
   @doc false
   defmacro __using__(_) do
@@ -31,7 +34,7 @@ defmodule Tirexs.River do
 
   @doc false
   def create_resource(definition) do
-    create_resource(definition, Tirexs.ElasticSearch.Config.new)
+    create_resource(definition, Tirexs.ElasticSearch.config())
   end
 
   @doc false
@@ -47,6 +50,6 @@ defmodule Tirexs.River do
   @doc false
   def to_resource_json(definition) do
     definition = Dict.delete(Dict.delete(definition, :name), :river)
-    JSEX.encode!(definition)
+    JSX.encode!(definition)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,6 @@ defmodule Tirexs.Mixfile do
   def application, do: []
 
   defp deps do
-    [ {:jsex, github: "talentdeficit/jsex"} ]
+    [ {:exjsx, github: "talentdeficit/exjsx", tag: "v3.1.0"} ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"jsex": {:git, "git://github.com/talentdeficit/jsex.git", "03ad4ff0967331afd01464857d41e5e497ed198c", []},
-  "jsx": {:git, "git://github.com/talentdeficit/jsx.git", "507fa4c41db33c81e925ab53f4d789d234aaff2f", [tag: "v2.0.1"]}}
+%{"exjsx": {:git, "git://github.com/talentdeficit/exjsx.git", "087e01df2457262dcc578d36b68fcdca41860f23", [tag: "v3.1.0"]},
+  "jsx": {:hex, :jsx, "2.4.0"}}

--- a/test/acceptances/bulk_test.exs
+++ b/test/acceptances/bulk_test.exs
@@ -3,9 +3,10 @@ Code.require_file "../../test_helper.exs", __ENV__.file
 defmodule Acceptances.BulkTest do
   use ExUnit.Case
   import Tirexs.Bulk
+  require Tirexs.ElasticSearch
 
   test :create do
-    settings = Tirexs.ElasticSearch.Config.new()
+    settings = Tirexs.ElasticSearch.config()
 
         Tirexs.ElasticSearch.delete("bear_test", settings)
 
@@ -31,7 +32,7 @@ defmodule Acceptances.BulkTest do
   end
 
   test :update do
-    settings = Tirexs.ElasticSearch.Config.new()
+    settings = Tirexs.ElasticSearch.config()
       Tirexs.ElasticSearch.delete("bear_test", settings)
 
     Tirexs.Bulk.store [index: "bear_test", refresh: false], settings do

--- a/test/acceptances/elastic_search_test.exs
+++ b/test/acceptances/elastic_search_test.exs
@@ -6,11 +6,13 @@ defmodule Acceptances.ElasticSearchTest do
   import Tirexs.Mapping, only: :macros
   import Tirexs.Bulk
   import Tirexs.ElasticSearch
+  require Tirexs.ElasticSearch
+  require Tirexs.Query
   import Tirexs.Search
 
 
   test :get_elastic_search_server do
-    settings = Tirexs.ElasticSearch.Config.new()
+    settings = Tirexs.ElasticSearch.config()
     {:error, _, _}  = get("missing_index", settings)
     {:ok, _, body}    = get("", settings)
 
@@ -19,7 +21,7 @@ defmodule Acceptances.ElasticSearchTest do
   end
 
   test :create_index do
-    settings = Tirexs.ElasticSearch.Config.new()
+    settings = Tirexs.ElasticSearch.config()
     delete("bear_test", settings)
     {:ok, _, body} = put("bear_test", settings)
     assert body[:acknowledged] == true
@@ -27,7 +29,7 @@ defmodule Acceptances.ElasticSearchTest do
   end
 
   test :delete_index do
-    settings = Tirexs.ElasticSearch.Config.new()
+    settings = Tirexs.ElasticSearch.config()
     put("bear_test", settings)
     {:ok, _, body} = delete("bear_test", settings)
     assert body[:acknowledged] == true
@@ -35,7 +37,7 @@ defmodule Acceptances.ElasticSearchTest do
 
 
   test :head do
-    settings = Tirexs.ElasticSearch.Config.new()
+    settings = Tirexs.ElasticSearch.config()
     delete("bear_test", settings)
     assert exist?("bear_test", settings) == false
 
@@ -45,7 +47,7 @@ defmodule Acceptances.ElasticSearchTest do
   end
 
   test :create_type_mapping do
-    settings = Tirexs.ElasticSearch.Config.new()
+    settings = Tirexs.ElasticSearch.config()
     index = [index: "bear_test", type: "bear_type"]
       mappings do
         indexes "mn_opts_", [type: "object"] do
@@ -75,7 +77,7 @@ defmodule Acceptances.ElasticSearchTest do
   end
 
   test :create_mapping_search do
-    settings = Tirexs.ElasticSearch.Config.new()
+    settings = Tirexs.ElasticSearch.config()
 
     delete("articles", settings)
 
@@ -130,8 +132,8 @@ defmodule Acceptances.ElasticSearchTest do
 
     result = Tirexs.Query.create_resource(s, settings)
 
-    assert result.count == 1
-    assert List.first(result.hits)[:_source][:id] == 2
+    assert Tirexs.Query.result(result, :count) == 1
+    assert List.first(Tirexs.Query.result(result, :hits))[:_source][:id] == 2
 
   end
 end

--- a/test/acceptances/loader_test.exs
+++ b/test/acceptances/loader_test.exs
@@ -4,11 +4,12 @@ defmodule Acceptances.LoaderTest do
   use ExUnit.Case
 
   import Tirexs.ElasticSearch
+  require Tirexs.ElasticSearch
 
   @path Path.join([File.cwd!, "examples"])
 
    test :load_dsl_file do
-     settings = Tirexs.ElasticSearch.Config.new()
+     settings = Tirexs.ElasticSearch.config()
 
      Tirexs.Loader.load_all(@path)
 
@@ -22,7 +23,7 @@ defmodule Acceptances.LoaderTest do
 
    test :river_dsl do
     river_path = Path.join([File.cwd!, "examples", "river"])
-    settings = Tirexs.ElasticSearch.Config.new()
+    settings = Tirexs.ElasticSearch.config()
 
     Tirexs.Loader.load_all(river_path)
 

--- a/test/acceptances/manage_test.exs
+++ b/test/acceptances/manage_test.exs
@@ -8,16 +8,18 @@ defmodule Acceptances.ManageTest do
 
   import Tirexs.Query
   import Tirexs.Mapping, only: :macros
+  require Tirexs.ElasticSearch
 
-  @settings Tirexs.ElasticSearch.Config.new()
+  @settings Tirexs.ElasticSearch.config()
 
   setup do
     create_index("bear_test", @settings)
-    :ok
-  end
 
-  teardown do
-    remove_index("bear_test", @settings)
+    on_exit fn ->
+      remove_index("bear_test", @settings)
+      :ok
+    end
+
     :ok
   end
 
@@ -76,7 +78,7 @@ defmodule Acceptances.ManageTest do
 
   test :validate_and_explain do
     doc = [user: "kimchy", post_date: "2009-11-15T14:12:12", message: "trying out Elastic Search"]
-    Tirexs.ElasticSearch.put("bear_test/my_type/1", JSEX.encode!(doc), @settings)
+    Tirexs.ElasticSearch.put("bear_test/my_type/1", JSX.encode!(doc), @settings)
 
     query = query do
       filtered do
@@ -97,14 +99,14 @@ defmodule Acceptances.ManageTest do
     assert Dict.get(body, :valid) == true
 
     {_, _, body} = Tirexs.Manage.explain([index: "bear_test", type: "my_type", id: 1, q: "message:search"], @settings)
-    body = JSEX.decode!(to_string(body), [{:labels, :atom}])
+    body = JSX.decode!(to_string(body), [{:labels, :atom}])
     assert Dict.get(body, :matched) == false
   end
 
   test :update do
     Tirexs.ElasticSearch.put("bear_test/my_type", @settings)
     doc = [user: "kimchy", counter: 1, post_date: "2009-11-15T14:12:12", message: "trying out Elastic Search", id: 1]
-    Tirexs.ElasticSearch.put("bear_test/my_type/1", JSEX.encode!(doc), @settings)
+    Tirexs.ElasticSearch.put("bear_test/my_type/1", JSX.encode!(doc), @settings)
 
     {_, _, body} = Tirexs.ElasticSearch.get("bear_test/my_type/1", @settings)
 

--- a/test/acceptances/percolator_test.exs
+++ b/test/acceptances/percolator_test.exs
@@ -2,9 +2,10 @@ Code.require_file "../../test_helper.exs", __ENV__.file
 defmodule Tirexs.PerlocatorTest do
   use ExUnit.Case
   import Tirexs.Percolator
+  require Tirexs.ElasticSearch
 
   test :percolator do
-    settings = Tirexs.ElasticSearch.Config.new()
+    settings = Tirexs.ElasticSearch.config()
     Tirexs.ElasticSearch.delete("_percolator/test/kuku", settings)
 
     percolator = percolator [index: "test", name: "kuku"] do

--- a/test/acceptances/scroll_test.exs
+++ b/test/acceptances/scroll_test.exs
@@ -4,10 +4,12 @@ defmodule Acceptances.ScrollTest do
   use ExUnit.Case
   import Tirexs.Search
   import Tirexs.Bulk
+  require Tirexs.ElasticSearch
+  require Tirexs.Query
 
   test :scroll do
 
-    settings = Tirexs.ElasticSearch.Config.new()
+    settings = Tirexs.ElasticSearch.config()
     Tirexs.ElasticSearch.delete("bear_test", settings)
 
     Tirexs.Bulk.store [index: "bear_test", refresh: false], settings do
@@ -35,7 +37,7 @@ defmodule Acceptances.ScrollTest do
     end
 
     body = Tirexs.Query.create_resource(s, settings, [scroll: "5m"])
-    assert body._scroll_id != nil
+    assert Tirexs.Query.result(body, :_scroll_id) != nil
   end
 
 end

--- a/test/acceptances/warmer_test.exs
+++ b/test/acceptances/warmer_test.exs
@@ -4,11 +4,16 @@ defmodule Acceptances.WarmerTest do
   import TestHelpers
 
   import Tirexs.Search.Warmer
+  require Tirexs.ElasticSearch
 
-  @settings Tirexs.ElasticSearch.Config.new()
+  @settings Tirexs.ElasticSearch.config()
 
-  teardown do
-    remove_index("bear_test", @settings)
+  setup do
+    on_exit fn ->
+      remove_index("bear_test", @settings)
+      :ok
+    end
+
     :ok
   end
 
@@ -30,8 +35,8 @@ defmodule Acceptances.WarmerTest do
       end
     end
 
-    Tirexs.ElasticSearch.put("bear_test", JSEX.encode!(warmers), @settings)
+    Tirexs.ElasticSearch.put("bear_test", JSX.encode!(warmers), @settings)
     {:ok, 200, body} = Tirexs.ElasticSearch.get("bear_test/_warmer/warmer_1", @settings)
-    assert Dict.get(body, :bear_test) |> Dict.get(:warmers) == [warmer_1: [types: [], source: [query: [match_all: []], facets: [facet_1: [terms: [field: "field"]]]]]]
+    assert Dict.get(body, :bear_test) |> Dict.get(:warmers) == %{warmer_1: %{types: [], source: %{query: %{match_all: []}, facets: %{facet_1: %{terms: %{field: "field"}}}}}}
   end
 end

--- a/test/tirexs/logger_test.exs
+++ b/test/tirexs/logger_test.exs
@@ -5,6 +5,6 @@ defmodule Tirexs.LoggerTest do
 
   test :to_curl do
     assert Tirexs.Logger.to_curl([d: 4]) == :ok
-    assert Tirexs.Logger.to_curl(JSEX.encode!([d: 4])) == :ok
+    assert Tirexs.Logger.to_curl(JSX.encode!([d: 4])) == :ok
   end
 end


### PR DESCRIPTION
Hey guys. I've made some changes for adaptation Tirexs for Elixir 1.0.

README was fixed too. The second code sample (mapping) doesn't work after populating an index. You show define mapping first. Otherwise ElasticSearch will do it for you automatically. But in case of auto-mapping you can't change mapping by your own. You will get errors like:

{:error, 400, "{\"error\":\"MergeMappingException[Merge failed with failures {[mapper [tags] has different index_analyzer, mapper [title] has different index_analyzer]}]\",\"status\":400}"}

Tests passing.

Hope these changes will be helpful for others.