### PR TITLE
Configure connection url using list or existing url

### DIFF
--- a/lib/tirexs/elastic_search.ex
+++ b/lib/tirexs/elastic_search.ex
@@ -2,11 +2,34 @@ require Record
 
 defmodule Tirexs.ElasticSearch do
 
+  @config %URI{ scheme: "http", userinfo: nil, host: "127.0.0.1", port: 9200 }
+
   @doc """
-  This module provides a simple convenience for connection options such as `port`, `uri`, `user`, `pass`
-  and functions for doing a `HTTP` request to `ElasticSearch` engine directly.
+  Get default configuration for `ElasticSearch` connection.
   """
-  Record.defrecord :config, [port: 9200, uri: "127.0.0.1", user: nil, pass: nil]
+  def config do
+    @config
+  end
+
+  @doc """
+  Set `ElasticSearch` connection from URL.
+  """
+  def config(url) when is_bitstring(url) do
+    URI.parse(url)
+  end
+
+  @doc """
+  Override default configuration for `ElasticSearch` connection from argument list.
+  Arguments must match those in Elixir's `URI` module.
+  """
+  def config(opts) when is_list(opts) do
+    Map.merge config, Enum.into(opts, %{})
+  end
+
+  @doc false
+  def config(config, part) do
+    config[part]
+  end
 
   @doc false
   def get(query_url, config) do
@@ -85,11 +108,7 @@ defmodule Tirexs.ElasticSearch do
   def get_body_json(body), do: JSX.decode!(to_string(body), [{:labels, :atom}])
 
   def make_url(query_url, config) do
-    if config(config, :port) == nil || config(config, :port) == 80 do
-      "http://#{config.uri}/#{query_url}"
-    else
-      "http://#{config(config, :uri)}:#{config(config, :port)}/#{query_url}"
-    end
+    %URI{config | path: "/#{query_url}"} |> to_string
   end
 
   defp make_headers, do: [{'Content-Type', 'application/json'}]

--- a/test/tirexs/config_test.exs
+++ b/test/tirexs/config_test.exs
@@ -1,0 +1,23 @@
+defmodule Tirexs.ElasticSearchTest do
+  use ExUnit.Case
+
+  import Tirexs.ElasticSearch
+
+  test "default config" do
+    assert make_url("articles", config) == "http://127.0.0.1:9200/articles"
+  end
+
+  test "key value config" do
+    assert make_url("articles", config(
+      scheme: "https",
+      userinfo: "user:pass",
+      host: "localhost",
+      port: 9201
+    )) == "https://user:pass@localhost:9201/articles"
+  end
+
+  test "url config" do
+    assert make_url("articles", config("https://user:pass@localhost:9201"))
+      == "https://user:pass@localhost:9201/articles"
+  end
+end


### PR DESCRIPTION
Replaced the config record with an URI for easier connection handling. This also adds https support.

Now you can change the default settings with options:
`settings = Tirexs.ElasticSearch.config(scheme: "https", userinfo: "user:pass")`

or with an URL:
`settings = Tirexs.ElasticSearch.config("https://user:pass@localhost:9201")`