### PR TITLE
Remove MIX_ENV=test when running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ notifications:
     - a.zatvornitskiy@gmail.com
 services:
   - elasticsearch
-script: "MIX_ENV=test mix test"
+script: "mix test"


### PR DESCRIPTION
`MIX_ENV=test` is implied by `mix test` so is not needed.