### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ elixir:
   - 1.0.2
 services:
   - elasticsearch
-script: "mix test"
 notifications:
   email: false
   slack:


### PR DESCRIPTION
Script can be simplified without the script section if the default is going to be used.