### PR TITLE
Make exjsx a hex based dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Tirexs.Mixfile do
   def application, do: []
 
   defp deps do
-    [ {:exjsx, github: "talentdeficit/exjsx", tag: "v3.1.0"} ]
+    [ {:exjsx, "~> 3.1.0"} ]
   end
 
   defp description do


### PR DESCRIPTION
When depending on a package using scm hex does not automatically handle dependency resolution for that dependency. Solution is to depend only on other hex dependencies.