### PR TITLE
Add inets and exjsx to runtime dependencies

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,9 @@ defmodule Tirexs.Mixfile do
     [ app: :tirexs, version: "0.7.1", elixir: "~> 1.0.0", description: description, package: package, deps: deps ]
   end
 
-  def application, do: []
+  def application do
+    [applications: [:exjsx, :inets]]
+  end
 
   defp deps do
     [ {:exjsx, "~> 3.1.0"} ]


### PR DESCRIPTION
When trying to use tirexs in my project I noticed that it was depending on those two libraries at runtime. This makes sure those are available when needed.