### PR TITLE
Added Index aliases API

### DIFF
--- a/lib/tirexs/manage.ex
+++ b/lib/tirexs/manage.ex
@@ -23,6 +23,10 @@ defmodule Tirexs.Manage do
     Tirexs.ElasticSearch.get(make_url("_explain", options), settings)
   end
 
+  def aliases(aliases_params, settings) do
+    Tirexs.ElasticSearch.post("_aliases", JSX.encode!(aliases_params), settings)
+  end
+
   def update(options, update_params, settings) do
     Tirexs.ElasticSearch.post(make_url("_update", options), JSX.encode!(update_params), settings)
   end


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/2.x/indices-aliases.html

I think that needs to define aliases API in tirexs. Thanks.