### PR TITLE
Evolve `Tirexs.HTTP` interface

### DIFF
--- a/lib/tirexs/http.ex
+++ b/lib/tirexs/http.ex
@@ -112,8 +112,13 @@ defmodule Tirexs.HTTP do
   end
 
   @doc false
-  def decode(body, opts \\ [{:labels, :atom}]) do
-    JSX.decode!(to_string(body), opts)
+  def decode(json, opts \\ [{:labels, :atom}]) do
+    JSX.decode(to_string(json), opts)
+  end
+
+  @doc false
+  def encode(term, opts \\ []) do
+    JSX.encode(term, opts)
   end
 
 

--- a/lib/tirexs/http.ex
+++ b/lib/tirexs/http.ex
@@ -19,13 +19,19 @@ defmodule Tirexs.HTTP do
   end
 
   @doc false
-  def put(path, uri, body) when is_binary(path) and is_map(uri) do
+  def put(path, uri, body) when is_binary(path) and is_map(uri) and is_list(body) do
+    if body == [], do: do_request(:put, url(path, uri)), else: put(path, uri, to_string(body))
+  end
+  def put(path, uri, body) when is_binary(path) and is_map(uri) and is_binary(body) do
     do_request(:put, url(path, uri), body)
   end
   def put(path, uri) when is_binary(path) and is_map(uri) do
     do_request(:put, url(path, uri))
   end
   def put(url_or_path_or_uri, body) when is_list(body) do
+    if body == [], do: do_request(:put, url(url_or_path_or_uri)), else: put(url_or_path_or_uri, to_string(body))
+  end
+  def put(url_or_path_or_uri, body) when is_binary(body) do
     do_request(:put, url(url_or_path_or_uri), body)
   end
   def put(url_or_path_or_uri) do
@@ -33,15 +39,19 @@ defmodule Tirexs.HTTP do
   end
 
   @doc false
-  def post(path, uri, body) when is_binary(path) and is_map(uri) do
-    unless body == [], do: body = to_string(body)
+  def post(path, uri, body) when is_binary(path) and is_map(uri) and is_list(body) do
+    if body == [], do: do_request(:post, url(path, uri)), else: post(path, uri, to_string(body))
+  end
+  def post(path, uri, body) when is_binary(path) and is_map(uri) and is_binary(body) do
     do_request(:post, url(path, uri), body)
   end
   def post(path, uri) when is_binary(path) and is_map(uri) do
     do_request(:post, url(path, uri))
   end
   def post(url_or_path_or_uri, body) when is_list(body) do
-    unless body == [], do: body = to_string(body)
+    if body == [], do: do_request(:post, url(url_or_path_or_uri), body), else: post(url_or_path_or_uri, to_string(body))
+  end
+  def post(url_or_path_or_uri, body) when is_binary(body) do
     do_request(:post, url(url_or_path_or_uri), body)
   end
   def post(url_or_path_or_uri) do

--- a/test/acceptances/http_test.exs
+++ b/test/acceptances/http_test.exs
@@ -37,8 +37,14 @@ defmodule Acceptances.HTTPTest do
     { :ok, 200, _ } = delete("/bear_test")
   end
 
-  test "posts some resource" do
+  test "posts and puts some resources" do
     { :ok, 200, _ } = put("/bear_test")
     { :ok, 200, _ } = post("/bear_test/_refresh")
   end
+
+  @tag skip: "pending"
+  test "posts some resource with body"
+
+  @tag skip: "pending"
+  test "puts some resource with body"
 end


### PR DESCRIPTION
Scope:
- [ ] Remove using `JSX.encode,decode` in favor of `HTTP.encode,decode`, #180 
- [x] `post,put` handles body as a `binary`