### PR TITLE
`Tirexs.Resources` module

### DIFF
--- a/lib/tirexs.ex
+++ b/lib/tirexs.ex
@@ -50,4 +50,7 @@ defmodule Tirexs do
 
   """
   defdelegate [load_file(file), load_file(file, relative_to)], to: Code
+
+  @doc false
+  defdelegate [bump(), bump(uri), bump!(), bump!(uri)], to: Tirexs.Resources
 end

--- a/lib/tirexs/manage.ex
+++ b/lib/tirexs/manage.ex
@@ -1,5 +1,5 @@
 defmodule Tirexs.Manage do
-  @moduledoc false
+  @moduledoc "warning: This module is completely outdated and will be removed in `v0.8.0`"
 
   import Tirexs.DSL.Logic
 
@@ -33,6 +33,7 @@ defmodule Tirexs.Manage do
 
   @doc false
   def aliases(aliases_params, settings) do
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.aliases/2` is deprecated, please use `Tirexs.Resources.APIs._aliases/2` instead\n" <> Exception.format_stacktrace
     Tirexs.ElasticSearch.post("_aliases", JSX.encode!(aliases_params), settings)
   end
 
@@ -55,11 +56,13 @@ defmodule Tirexs.Manage do
 
   @doc false
   def refresh(index, settings) when is_binary(index) do
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.refresh/2` is deprecated, please use `Tirexs.Resources.APIs._refresh/2` instead\n" <> Exception.format_stacktrace
     Tirexs.ElasticSearch.post(to_string(index) <> "/_refresh", settings)
   end
 
   @doc false
   def refresh(indexes, settings) when is_list(indexes) do
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.refresh/2` is deprecated, please use `Tirexs.Resources.APIs._refresh/2` instead\n" <> Exception.format_stacktrace
     indexes = Enum.join(indexes, ",")
     refresh(indexes, settings)
   end

--- a/lib/tirexs/resources.ex
+++ b/lib/tirexs/resources.ex
@@ -1,0 +1,75 @@
+defmodule Tirexs.Resources do
+  @moduledoc false
+
+  import Tirexs.HTTP
+
+
+  @doc false
+  def exists?(path, uri) when is_binary(path) and is_map(uri) do
+    ok?(head(path, uri))
+  end
+  def exists?(url_or_path_or_uri) do
+    ok?(head(url_or_path_or_uri))
+  end
+  def exists!(path, uri) when is_binary(path) and is_map(uri) do
+    head!(path, uri)
+  end
+  def exists!(url_or_path_or_uri) do
+    head!(url_or_path_or_uri)
+  end
+
+  @doc false
+  def urn(part) when is_binary(part) do
+    normalize(part)
+  end
+  def urn(parts)  when is_list(parts) do
+    Enum.map(parts, fn(part) -> normalize(part) end) |> Enum.join("/") |> String.replace("/?", "?")
+  end
+  def urn(a, b), do: urn([a ,b])
+  def urn(a, b, c), do: urn([a,b,c])
+  def urn(a, b, c, d), do: urn([a,b,c,d])
+  def urn(a, b, c, d, e), do: urn([a,b,c,d,e])
+  def urn(a, b, c, d, e, f), do: urn([a,b,c,d,e,f])
+  def urn(a, b, c, d, e, f, g), do: urn([a,b,c,d,e,f,g])
+
+  @doc false
+  def normalize(resource) when is_binary(resource) do
+    String.strip(resource) |> String.replace_prefix("/", "")
+  end
+  def normalize({ params }) do
+    "?" <> URI.encode_query(params)
+  end
+  def normalize(resource) do
+    pluralize(resource) |> normalize()
+  end
+
+  @doc false
+  def pluralize(resource) when is_binary(resource), do: resource
+  def pluralize(resource), do: Enum.join(resource, ",")
+
+  @doc false
+  def bump(), do: __t(:bump)
+  def bump(uri), do: __t(:bump, uri)
+  def bump!(), do: __t(:bump!)
+  def bump!(uri), do: __t(:bump!, uri)
+
+
+  @doc false
+  def __c(urn, meta) do
+    if ctx = Process.delete(:tirexs_resources_chain) do
+      args = case urn do
+        urn when is_binary(urn) -> [ urn, ctx[:uri] ]
+        [ urn, body ]           -> [ urn, ctx[:uri], body ]
+      end
+      Kernel.apply(Tirexs.HTTP, meta[ctx[:label]], args)
+    else
+      urn
+    end
+  end
+
+  @doc false
+  defp __t(label, uri \\ Tirexs.ENV.get_uri_env()) do
+    Process.put(:tirexs_resources_chain, [label: label, uri: uri])
+    Tirexs.Resources.APIs
+  end
+end

--- a/lib/tirexs/resources.ex
+++ b/lib/tirexs/resources.ex
@@ -1,24 +1,38 @@
 defmodule Tirexs.Resources do
-  @moduledoc false
+  @moduledoc """
+  The intend is to provide an abstraction for dealing with ES resources.
+
+  The interface of this module is aware about elasticsearch REST APIs conventions.
+  Meanwhile, a `Tirexs.HTTP` provides just a general interface.
+
+  """
 
   import Tirexs.HTTP
 
 
-  @doc false
-  def exists?(path, uri) when is_binary(path) and is_map(uri) do
-    ok?(head(path, uri))
-  end
-  def exists?(url_or_path_or_uri) do
-    ok?(head(url_or_path_or_uri))
-  end
-  def exists!(path, uri) when is_binary(path) and is_map(uri) do
-    head!(path, uri)
-  end
-  def exists!(url_or_path_or_uri) do
-    head!(url_or_path_or_uri)
-  end
+  @doc "the same as `ok?(head(path, uri))`"
+  def exists?(path, uri), do: ok?(head(path, uri))
+  def exists?(url_or_path_or_uri), do: ok?(head(url_or_path_or_uri))
 
-  @doc false
+  @doc "the same as `head!(path, uri)`"
+  def exists!(path, uri), do: head!(path, uri)
+  def exists!(url_or_path_or_uri), do: head!(url_or_path_or_uri)
+
+  @doc """
+  Composes an URN from parts into request ready path as a binary string.
+
+  ## Examples:
+
+      iex> urn ["bear_test", "/_alias", ["2015", "2016"]]
+      "bear_test/_alias/2015,2016"
+
+      iex> urn [["bear_test", "another_bear_test"], "_refresh", { [ignore_unavailable: true] }]
+      "bear_test,another_bear_test/_refresh?ignore_unavailable=true"
+
+      iex> urn("bear_test", "bear_type", "10", "_explain?analyzer=some")
+      "bear_test/bear_type/10/_explain?analyzer=some"
+
+  """
   def urn(part) when is_binary(part) do
     normalize(part)
   end
@@ -47,7 +61,27 @@ defmodule Tirexs.Resources do
   def pluralize(resource) when is_binary(resource), do: resource
   def pluralize(resource), do: Enum.join(resource, ",")
 
-  @doc false
+  @doc """
+  Tries to bump resource. This one just makes a request and behaves like a proxy to
+  one of avalable resource helper. You're able to bump any resources which are defined in
+  `Tirexs.Resources.APIs`.
+
+  Let's consider the following use case:
+
+      iex> path = Tirexs.Resources.APIs._refresh(["bear_test", "duck_test"], { [force: false] })
+      "bear_test,duck_test/_refresh?force=false"
+
+      iex> Tirexs.HTTP.post(path)
+      { :ok, 200, ... }
+
+  With bump, the same is:
+
+      iex> bump._refresh(["bear_test", "duck_test"], { [force: false] })
+      { :ok, 200, ... }
+
+  Play with resources you have and see what kind of HTTP verb is used.
+
+  """
   def bump(), do: __t(:bump)
   def bump(uri), do: __t(:bump, uri)
   def bump!(), do: __t(:bump!)

--- a/lib/tirexs/resources/apis.ex
+++ b/lib/tirexs/resources/apis.ex
@@ -1,0 +1,43 @@
+defmodule Tirexs.Resources.APIs do
+  @moduledoc false
+
+
+  alias Tirexs.Resources.Indicies
+
+
+  ## Index Settings
+
+  @doc false
+  defdelegate [ _analyze(), _analyze(a), _analyze(a, b), _analyze(a, b, c) ], to: Indicies
+  defdelegate [ _warmer(), _warmer(a), _warmer(a, b), _warmer(a, b, c) ], to: Indicies
+  defdelegate [ _template(), _template(a), _template(a, b), _template(a, b, c) ], to: Indicies
+  defdelegate [ _settings(), _settings(a), _settings(a, b), _settings(a, b, c) ], to: Indicies
+
+  ## Index Management
+
+  @doc false
+  defdelegate [ _open(), _open(a), _open(a, b), _open(a, b, c) ], to: Indicies
+  defdelegate [ _close(), _close(a), _close(a, b), _close(a, b, c) ], to: Indicies
+  ## Alias Management
+
+  @doc false
+  defdelegate [ _aliases(), _aliases(a), _aliases(a, b), _aliases(a, b, c) ], to: Indicies
+  defdelegate [ _alias(), _alias(a), _alias(a, b), _alias(a, b, c) ], to: Indicies
+
+  ## Status Management
+
+  @doc false
+  defdelegate [ _refresh(), _refresh(a), _refresh(a, b), _refresh(a, b, c) ], to: Indicies
+  defdelegate [ _flush(), _flush(a), _flush(a, b), _flush(a, b, c) ], to: Indicies
+  defdelegate [ _forcemerge(), _forcemerge(a), _forcemerge(a, b), _forcemerge(a, b, c) ], to: Indicies
+  defdelegate [ _upgrade(), _upgrade(a), _upgrade(a, b), _upgrade(a, b, c) ], to: Indicies
+  defdelegate [ _cache_clear(), _cache_clear(a), _cache_clear(a, b), _cache_clear(a, b, c) ], to: Indicies
+
+  ## Monitoring Management
+
+  @doc false
+  defdelegate [ _stats(), _stats(a), _stats(a, b), _stats(a, b, c) ], to: Indicies
+  defdelegate [ _segments(), _segments(a), _segments(a, b), _segments(a, b, c) ], to: Indicies
+  defdelegate [ _recovery(), _recovery(a), _recovery(a, b), _recovery(a, b, c) ], to: Indicies
+  defdelegate [ _shard_stores(), _shard_stores(a), _shard_stores(a, b), _shard_stores(a, b, c) ], to: Indicies
+end

--- a/lib/tirexs/resources/apis.ex
+++ b/lib/tirexs/resources/apis.ex
@@ -5,6 +5,13 @@ defmodule Tirexs.Resources.APIs do
   alias Tirexs.Resources.Indicies
 
 
+  ## Mapping Management
+
+  @doc false
+  defdelegate [ _all_mapping() ], to: Indicies
+  defdelegate [ _mapping(), _mapping(a), _mapping(a, b), _mapping(a, b, c) ], to: Indicies
+  defdelegate [ _field_mapping(a), _field_mapping(a, b), _field_mapping(a, b, c),  _field_mapping(a, b, c)], to: Indicies
+
   ## Index Settings
 
   @doc false

--- a/lib/tirexs/resources/apis.ex
+++ b/lib/tirexs/resources/apis.ex
@@ -1,6 +1,41 @@
 defmodule Tirexs.Resources.APIs do
-  @moduledoc false
+  @moduledoc """
+  This module provides a set of API helpers. Helpers are useful for buiding
+  an URN part of particular request. Most commonly the result of this would
+  be used for dealing directly with variety of available `Tirexs.HTTP` functions.
 
+  ## Examples:
+
+      iex> APIs._refresh({ [force: true] })
+      "_refresh?force=true"
+
+      iex> APIs._refresh(["bear_test", "duck_test"], { [force: false] })
+      "bear_test,duck_test/_refresh?force=false"
+
+      iex> APIs._field_mapping(["bear_test", "duck_test"], "message", {[ ignore_unavailable: true ]})
+      "bear_test,duck_test/_mapping/message/field?ignore_unavailable=true"
+
+      iex> APIs._field_mapping("_all", "tw*", ["*.id", "*.text"])
+      "_all/_mapping/tw*/field/*.id,*.text"
+
+  NOTICE: All of helpers have the same interface, behaviour and almost don't care about the details.
+  It means, you have a chance to create a complety unsupported API call.
+
+  ## For instance:
+
+      iex> APIs._refresh(["bear_test", "duck_test"], ["a", "b"], {[ human: true ]})
+      "bear_test,duck_test/_refresh/a,b?human=true"
+
+
+  A `Tirexs.Resources.urn/x` is responsible for concatenation parts all together.
+
+  ## Feature requests
+
+  Feature requests are welcome and should be discussed. But take a moment to find
+  out whether your idea fits with the scope and aims of the project. Please provide
+  as much detail and context as possible (from `CONTRIBUTING.md`).
+
+  """
 
   alias Tirexs.Resources.Indicies
 

--- a/lib/tirexs/resources/indicies.ex
+++ b/lib/tirexs/resources/indicies.ex
@@ -4,6 +4,28 @@ defmodule Tirexs.Resources.Indicies do
   import Tirexs.Resources, only: [urn: 1, urn: 2, urn: 3, urn: 4, __c: 2]
 
 
+  ## Mapping Management
+
+  @doc false
+  @r [action: "/_mapping", bump: :put, bump!: :put!]
+  def _mapping(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _mapping(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _mapping({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _mapping(a), do: __c(urn(a, @r[:action]), @r)
+  def _mapping(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  def _all_mapping(), do: _mapping("_all")
+
+  @doc false
+  @r [action: "/_mapping/field", bump: :get, bump!: :get!]
+  def _field_mapping(a, b, c, {d}), do: __c(urn([a, "_mapping", b, "field", c, {d}]), @r)
+  def _field_mapping(a, b, c), do: __c(urn([a, "_mapping", b, "field", c]), @r)
+  def _field_mapping(a, {b}), do: __c(urn(@r[:action], a, {b}), @r)
+  def _field_mapping(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _field_mapping(a), do: __c(urn(a, @r[:action]), @r)
+
+
   ## Index Settings
 
   @doc false
@@ -38,6 +60,7 @@ defmodule Tirexs.Resources.Indicies do
   def _settings(a), do: __c(urn(a, @r[:action]), @r)
   def _settings(), do: __c(urn(@r[:action]), @r)
 
+
   ## Index Management
 
   @doc false
@@ -55,6 +78,7 @@ defmodule Tirexs.Resources.Indicies do
   def _close({a}), do: __c(urn(@r[:action], {a}), @r)
   def _close(a), do: __c(urn(a, @r[:action]), @r)
   def _close(), do: __c(urn(@r[:action]), @r)
+
 
   ## Alias Management
 

--- a/lib/tirexs/resources/indicies.ex
+++ b/lib/tirexs/resources/indicies.ex
@@ -1,0 +1,153 @@
+defmodule Tirexs.Resources.Indicies do
+  @moduledoc false
+
+  import Tirexs.Resources, only: [urn: 1, urn: 2, urn: 3, urn: 4, __c: 2]
+
+
+  ## Index Settings
+
+  @doc false
+  @r [action: "/_analyze", bump: :get, bump!: :get!]
+  def _analyze(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _analyze(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _analyze({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _analyze(a), do: __c(urn(a, @r[:action]), @r)
+  def _analyze(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_warmer", bump: :put, bump!: :put!]
+  def _warmer(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _warmer(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _warmer({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _warmer(a), do: __c(urn(a, @r[:action]), @r)
+  def _warmer(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_template", bump: :put, bump!: :put!]
+  def _template(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _template(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _template({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _template(a), do: __c(urn(a, @r[:action]), @r)
+  def _template(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_settings", bump: :get, bump!: :get!]
+  def _settings(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _settings(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _settings({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _settings(a), do: __c(urn(a, @r[:action]), @r)
+  def _settings(), do: __c(urn(@r[:action]), @r)
+
+  ## Index Management
+
+  @doc false
+  @r [action: "/_open", bump: :post, bump!: :post!]
+  def _open(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _open(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _open({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _open(a), do: __c(urn(a, @r[:action]), @r)
+  def _open(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_close", bump: :post, bump!: :post!]
+  def _close(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _close(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _close({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _close(a), do: __c(urn(a, @r[:action]), @r)
+  def _close(), do: __c(urn(@r[:action]), @r)
+
+  ## Alias Management
+
+  @doc false
+  @r [action: "/_aliases"]
+  def _aliases(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _aliases(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _aliases({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _aliases(a), do: __c(urn(a, @r[:action]), @r)
+  def _aliases(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_alias", bump: :put, bump!: :put!]
+  def _alias(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _alias(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _alias({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _alias(a), do: __c(urn(a, @r[:action]), @r)
+  def _alias(), do: __c(urn(@r[:action]), @r)
+
+
+  ## Status Management
+
+  @doc false
+  @r [action: "/_refresh", bump: :post, bump!: :post!]
+  def _refresh(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _refresh(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _refresh({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _refresh(a), do: __c(urn(a, @r[:action]), @r)
+  def _refresh(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_flush", bump: :post, bump!: :post!]
+  def _flush(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _flush(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _flush({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _flush(a), do: __c(urn(a, @r[:action]), @r)
+  def _flush(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_forcemerge", bump: :post, bump!: :post!]
+  def _forcemerge(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _forcemerge(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _forcemerge({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _forcemerge(a), do: __c(urn(a, @r[:action]), @r)
+  def _forcemerge(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_upgrade", bump: :post, bump!: :post!]
+  def _upgrade(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _upgrade(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _upgrade({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _upgrade(a), do: __c(urn(a, @r[:action]), @r)
+  def _upgrade(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_cache/clear", bump: :post, bump!: :post!]
+  def _cache_clear(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _cache_clear({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _cache_clear(a), do: __c(urn(a, @r[:action]), @r)
+  def _cache_clear(), do: __c(urn(@r[:action]), @r)
+
+
+  ## Monitoring Management
+
+  @doc false
+  @r [action: "/_stats", bump: :get, bump!: :get!]
+  def _stats(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _stats(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _stats({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _stats(a), do: __c(urn(a, @r[:action]), @r)
+  def _stats(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_segments", bump: :get, bump!: :get!]
+  def _segments(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _segments(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _segments({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _segments(a), do: __c(urn(a, @r[:action]), @r)
+  def _segments(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_recovery", bump: :get, bump!: :get!]
+  def _recovery(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _recovery(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _recovery({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _recovery(a), do: __c(urn(a, @r[:action]), @r)
+  def _recovery(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_shard_stores", bump: :get, bump!: :get!]
+  def _shard_stores(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _shard_stores(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _shard_stores({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _shard_stores(a), do: __c(urn(a, @r[:action]), @r)
+  def _shard_stores(), do: __c(urn(@r[:action]), @r)
+end

--- a/lib/tirexs/resources/indicies.ex
+++ b/lib/tirexs/resources/indicies.ex
@@ -1,5 +1,12 @@
 defmodule Tirexs.Resources.Indicies do
-  @moduledoc false
+  @moduledoc """
+  Provides URN builders for indices APIs.
+
+  `Tirexs.Resources.APIs` describes the main interface and available options.
+
+  The indices APIs are used to manage individual indices, index settings, aliases, mappings, index templates and warmers.
+
+  """
 
   import Tirexs.Resources, only: [urn: 1, urn: 2, urn: 3, urn: 4, __c: 2]
 

--- a/test/acceptances/manage_test.exs
+++ b/test/acceptances/manage_test.exs
@@ -105,6 +105,22 @@ defmodule Acceptances.ManageTest do
     assert Dict.get(body, :matched) == false
   end
 
+  test :aliases do
+    queries = aliases do
+      add    index: "bear_test", alias: "bear_test_alias"
+    end
+    Tirexs.Manage.aliases queries, @settings
+
+    queries = aliases do
+      remove index: "bear_test", alias: "bear_test_alias"
+      add    index: "bear_test", alias: "bear_test_alias1"
+    end
+    Tirexs.Manage.aliases queries, @settings
+
+    {_, _, body} = Tirexs.ElasticSearch.get("_aliases", @settings)
+    assert body[:bear_test] == %{aliases: %{bear_test_alias1: %{}}}
+  end
+
   test :update do
     Tirexs.ElasticSearch.put("bear_test/my_type", @settings)
     doc = [user: "kimchy", counter: 1, post_date: "2009-11-15T14:12:12", message: "trying out Elastic Search", id: 1]

--- a/test/acceptances/manage_test.exs
+++ b/test/acceptances/manage_test.exs
@@ -105,22 +105,6 @@ defmodule Acceptances.ManageTest do
     assert Dict.get(body, :matched) == false
   end
 
-  test :aliases do
-    queries = aliases do
-      add    index: "bear_test", alias: "bear_test_alias"
-    end
-    Tirexs.Manage.aliases queries, @settings
-
-    queries = aliases do
-      remove index: "bear_test", alias: "bear_test_alias"
-      add    index: "bear_test", alias: "bear_test_alias1"
-    end
-    Tirexs.Manage.aliases queries, @settings
-
-    {_, _, body} = Tirexs.ElasticSearch.get("_aliases", @settings)
-    assert body[:bear_test] == %{aliases: %{bear_test_alias1: %{}}}
-  end
-
   test :update do
     Tirexs.ElasticSearch.put("bear_test/my_type", @settings)
     doc = [user: "kimchy", counter: 1, post_date: "2009-11-15T14:12:12", message: "trying out Elastic Search", id: 1]

--- a/test/acceptances/resources/indicies_test.exs
+++ b/test/acceptances/resources/indicies_test.exs
@@ -1,0 +1,37 @@
+defmodule Acceptances.Resources.IndiciesTest do
+  use ExUnit.Case
+
+  alias Tirexs.{HTTP, Resources}
+
+
+  setup do
+    HTTP.delete("bear_test") && :ok
+  end
+
+
+  test "_refresh/1" do
+    { :ok, 200, _ } = HTTP.put("bear_test")
+    { :ok, 200, _ } = Resources.bump._refresh("bear_test")
+  end
+
+  test "tries _refresh/1" do
+    { :error, 404, _ } = Resources.bump._refresh("unknown")
+  end
+
+  test "tries _refresh!/1" do
+    assert_raise(RuntimeError, fn -> Resources.bump!._refresh("unknown") end)
+  end
+
+  test "_flush/1" do
+    { :ok, 200, _ } = HTTP.put("bear_test")
+    { :ok, 200, _ } = Resources.bump._flush("bear_test")
+  end
+
+  test "tries _flush/1" do
+    { :error, 404, _ } = Resources.bump._flush("unknown")
+  end
+
+  test "tries _flush!/1" do
+    assert_raise(RuntimeError, fn -> Resources.bump!._flush("unknown") end)
+  end
+end

--- a/test/acceptances/resources_test.exs
+++ b/test/acceptances/resources_test.exs
@@ -1,0 +1,29 @@
+defmodule Acceptances.ResourcesTest do
+  use ExUnit.Case
+
+  alias Tirexs.{HTTP, Resources}
+
+
+  setup do
+    HTTP.delete("bear_test") && :ok
+  end
+
+
+  test "exists?/1" do
+    { :ok, 200, _ } = HTTP.put("bear_test")
+    assert Resources.exists?("bear_test")
+  end
+
+  test "tries exists?/1" do
+    refute Resources.exists?("unknown")
+  end
+
+  test "exists!/1" do
+    { :ok, 200, _ } = HTTP.put("bear_test")
+    assert Resources.exists!("bear_test")
+  end
+
+  test "tries exists!/1" do
+    assert_raise(RuntimeError, fn -> Resources.exists!("unknown") end)
+  end
+end

--- a/test/tirexs/resources/indicies_test.exs
+++ b/test/tirexs/resources/indicies_test.exs
@@ -7,7 +7,8 @@ defmodule Tirexs.Resources.IndiciesTest do
   @resources [
     "_refresh", "_flush", "_forcemerge", "_upgrade", "_alias", "_aliases",
     "_stats", "_segments", "_recovery", "_shard_stores", "_close", "_open",
-    "_analyze", "_warmer", "_template", "_settings"
+    "_analyze", "_warmer", "_template", "_settings",
+    "_mapping"
   ]
 
   test ~S/functions like a '_refresh()'/ do
@@ -103,8 +104,28 @@ defmodule Tirexs.Resources.IndiciesTest do
     assert actual == "_cache/clear"
   end
 
+  test ~S/functions like a '_all_mapping()'/ do
+    actual = Indicies._all_mapping()
+    assert actual == "_all/_mapping"
+  end
+
   test ~S/functions like a '_cache_clear(["bear_test", "duck_test"])'/ do
     actual = Indicies._cache_clear(["bear_test", "duck_test"])
     assert actual == "bear_test,duck_test/_cache/clear"
+  end
+
+  test ~S/functions like a '_field_mapping(["bear_test", "duck_test"])'/ do
+    actual = Indicies._field_mapping(["bear_test", "duck_test"])
+    assert actual == "bear_test,duck_test/_mapping/field"
+  end
+
+  test ~S/functions like a '_field_mapping(["bear_test", "duck_test"], "message")'/ do
+    actual = Indicies._field_mapping(["bear_test", "duck_test"], "message")
+    assert actual == "bear_test,duck_test/_mapping/field/message"
+  end
+
+  test ~S/functions like a '_field_mapping("_all", "tw*", "*.id")'/ do
+    actual = Indicies._field_mapping("_all", "tw*", "*.id")
+    assert actual == "_all/_mapping/tw*/field/*.id"
   end
 end

--- a/test/tirexs/resources/indicies_test.exs
+++ b/test/tirexs/resources/indicies_test.exs
@@ -1,0 +1,110 @@
+defmodule Tirexs.Resources.IndiciesTest do
+  use ExUnit.Case
+
+  alias Tirexs.Resources.Indicies
+
+
+  @resources [
+    "_refresh", "_flush", "_forcemerge", "_upgrade", "_alias", "_aliases",
+    "_stats", "_segments", "_recovery", "_shard_stores", "_close", "_open",
+    "_analyze", "_warmer", "_template", "_settings"
+  ]
+
+  test ~S/functions like a '_refresh()'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh()
+      actual = Kernel.apply(Indicies, String.to_atom(resource), [])
+      assert actual == "#{resource}"
+    end
+  end
+
+  test ~S/functions like a '_refresh({ [local: true] })'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh({ [local: true] })
+      actual = Kernel.apply(Indicies, String.to_atom(resource), [{ [local: true] }])
+      assert actual == "#{resource}?local=true"
+    end
+  end
+
+  test ~S/functions like a '_refresh({ %{local: true} })'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh({ %{local: true} })
+      actual = Kernel.apply(Indicies, String.to_atom(resource), [{ %{local: true} }])
+      assert actual == "#{resource}?local=true"
+    end
+  end
+
+  test ~S/functions like a '_refresh("bear_test")'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh("bear_test")
+      actual = Kernel.apply(Indicies, String.to_atom(resource), ["bear_test"])
+      assert actual == "bear_test/#{resource}"
+    end
+  end
+
+  test ~S/functions like a '_refresh("bear_test", { [local: false] })'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh("bear_test", { [local: false] })
+      actual = Kernel.apply(Indicies, String.to_atom(resource), ["bear_test", { [local: false] }])
+      assert actual == "bear_test/#{resource}?local=false"
+    end
+  end
+
+  test ~S/functions like a '_refresh(["bear_test", "duck_test"])'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh(["bear_test", "duck_test"])
+      actual = Kernel.apply(Indicies, String.to_atom(resource), [["bear_test", "duck_test"]])
+      assert actual == "bear_test,duck_test/#{resource}"
+    end
+  end
+
+  test ~S/functions like a '_refresh(["bear_test", "duck_test"], { [local: false] })'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh(["bear_test", "duck_test"], { [local: false] })
+      actual = Kernel.apply(Indicies, String.to_atom(resource), [["bear_test", "duck_test"], { [local: false] }])
+      assert actual == "bear_test,duck_test/#{resource}?local=false"
+    end
+  end
+
+  test ~S/functions like a '_refresh("bear_test", "2015")'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh("bear_test", "2015")
+      actual = Kernel.apply(Indicies, String.to_atom(resource), ["bear_test", "2015"])
+      assert actual == "bear_test/#{resource}/2015"
+    end
+  end
+
+  test ~S/functions like a '_refresh(["bear_test", "duck_test"], "2015")'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh(["bear_test", "duck_test"], "2015")
+      actual = Kernel.apply(Indicies, String.to_atom(resource), [["bear_test", "duck_test"], "2015"])
+      assert actual == "bear_test,duck_test/#{resource}/2015"
+    end
+  end
+
+  test ~S/functions like a '_refresh("bear_test", "2015", { [local: true] })'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh("bear_test", "2015", { [local: true] })
+      actual = Kernel.apply(Indicies, String.to_atom(resource), ["bear_test", "2015", { [local: true] }])
+      assert actual == "bear_test/#{resource}/2015?local=true"
+    end
+  end
+
+  test ~S/functions like a '_refresh("bear_test", "2015", { %{local: true} })'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh("bear_test", "2015", { %{local: true} })
+      actual = Kernel.apply(Indicies, String.to_atom(resource), ["bear_test", "2015", { %{local: true} }])
+      assert actual == "bear_test/#{resource}/2015?local=true"
+    end
+  end
+
+  test ~S/functions like a '_cache_clear()'/ do
+    actual = Indicies._cache_clear()
+    assert actual == "_cache/clear"
+  end
+
+  test ~S/functions like a '_cache_clear(["bear_test", "duck_test"])'/ do
+    actual = Indicies._cache_clear(["bear_test", "duck_test"])
+    assert actual == "bear_test,duck_test/_cache/clear"
+  end
+end

--- a/test/tirexs/resources_test.exs
+++ b/test/tirexs/resources_test.exs
@@ -1,0 +1,142 @@
+defmodule Tirexs.ResourcesTest do
+  use ExUnit.Case
+
+  # alias Tirexs.{HTTP, Resources}
+  import Tirexs.Resources
+
+
+  test "urn/1" do
+    actual = urn("/_refresh")
+    assert actual == "_refresh"
+  end
+
+  test "urn/1 with params as string" do
+    actual = urn("_upgrade?wait_for_completion=true")
+    assert actual == "_upgrade?wait_for_completion=true"
+  end
+
+  test "urn/2 with params as list" do
+    actual = urn("/_upgrade", { [wait_for_completion: true] })
+    assert actual == "_upgrade?wait_for_completion=true"
+  end
+
+  test "urn/2 with params as map" do
+    actual = urn("/_upgrade", { %{wait_for_completion: true} })
+    assert actual == "_upgrade?wait_for_completion=true"
+  end
+
+  test "urn/2 as string" do
+    actual = urn("bear_test", "/_refresh")
+    assert actual == "bear_test/_refresh"
+  end
+
+  test "urn/2 as string with params as string" do
+    actual = urn("bear_test", "/_refresh?ignore_unavailable=true")
+    assert actual == "bear_test/_refresh?ignore_unavailable=true"
+  end
+
+  test "urn/3 as string with params as list" do
+    actual = urn("bear_test", "/_refresh", { [ignore_unavailable: true] })
+    assert actual == "bear_test/_refresh?ignore_unavailable=true"
+  end
+
+  test "urn/3 as string with params as map" do
+    actual = urn("bear_test", "/_refresh", { %{ignore_unavailable: true} })
+    assert actual == "bear_test/_refresh?ignore_unavailable=true"
+  end
+
+  test "urn/2 as list" do
+    actual = urn(["bear_test", "another_bear_test"], "/_refresh")
+    assert actual == "bear_test,another_bear_test/_refresh"
+  end
+
+  test "urn/3 as list with params as list" do
+    actual = urn(["bear_test", "another_bear_test"], "/_refresh", { [ignore_unavailable: true] })
+    assert actual == "bear_test,another_bear_test/_refresh?ignore_unavailable=true"
+  end
+
+  test "urn/3 as list with params as map" do
+    actual = urn(["bear_test", "another_bear_test"], "/_refresh", { %{ignore_unavailable: true} })
+    assert actual == "bear_test,another_bear_test/_refresh?ignore_unavailable=true"
+  end
+
+  test "urn/3 as string and name part as string" do
+    actual = urn("bear_test", "/_alias", "2015")
+    assert actual == "bear_test/_alias/2015"
+  end
+
+  test "urn/3 as string and name part as string with params as list" do
+    actual = urn("bear_test", "/_alias", "2015", { [local: true] })
+    assert actual == "bear_test/_alias/2015?local=true"
+  end
+
+  test "urn/3 as string and name part as string with params as map" do
+    actual = urn("bear_test", "/_alias", "2015", { %{local: true} })
+    assert actual == "bear_test/_alias/2015?local=true"
+  end
+
+  test "urn/3 as string and name part as a list" do
+    actual = urn("bear_test", "/_alias", ["2015", "2016"])
+    assert actual == "bear_test/_alias/2015,2016"
+  end
+
+  test "urn/3 as string and name part as a list with params list" do
+    actual = urn("bear_test", "/_alias", ["2015", "2016"], { [local: true] })
+    assert actual == "bear_test/_alias/2015,2016?local=true"
+  end
+
+  test "urn/3 as string and name part as a list with params map" do
+    actual = urn("bear_test", "/_alias", ["2015", "2016"], { %{local: true} })
+    assert actual == "bear_test/_alias/2015,2016?local=true"
+  end
+
+  test "urn/3 as list and string" do
+    actual = urn(["bear_test", "another_bear_test"], "/_alias", "2015")
+    assert actual == "bear_test,another_bear_test/_alias/2015"
+  end
+
+  test "urn/3 as list and name part as string with params as list" do
+    actual = urn(["bear_test", "another_bear_test"], "/_alias", "2015", { [local: true] })
+    assert actual == "bear_test,another_bear_test/_alias/2015?local=true"
+  end
+
+  test "urn/3 as list and name part as string with params as map" do
+    actual = urn(["bear_test", "another_bear_test"], "/_alias", "2015", { %{local: true} })
+    assert actual == "bear_test,another_bear_test/_alias/2015?local=true"
+  end
+
+  test "urn/3 as list and list" do
+    actual = urn(["bear_test", "another_bear_test"], "/_alias", ["2015", "2016"])
+    assert actual == "bear_test,another_bear_test/_alias/2015,2016"
+  end
+
+  test "urn/3 as list and name part as list with params as list" do
+    actual = urn(["bear_test", "another_bear_test"], "/_alias", ["2015", "2016"], { [local: true] })
+    assert actual == "bear_test,another_bear_test/_alias/2015,2016?local=true"
+  end
+
+  test "urn/3 as list and name part as list with params as map" do
+    actual = urn(["bear_test", "another_bear_test"], "/_alias", ["2015", "2016"], { %{local: true} })
+    assert actual == "bear_test,another_bear_test/_alias/2015,2016?local=true"
+  end
+
+  test ~S| urn("bear_test", "bear_type", "10", "/_explain") | do
+    actual = urn("bear_test", "bear_type", "10", "/_explain")
+    assert actual == "bear_test/bear_type/10/_explain"
+  end
+
+  test ~S| urn("bear_test", "bear_type", "10", "/_explain?analyzer=some") | do
+    actual = urn("bear_test", "bear_type", "10", "/_explain?analyzer=some")
+    assert actual == "bear_test/bear_type/10/_explain?analyzer=some"
+  end
+
+  test ~S| urn("bear_test", "bear_type", "10", "/_explain", { [analyzer: "some"] }) | do
+    actual = urn("bear_test", "bear_type", "10", "/_explain", { [analyzer: "some"] })
+    assert actual == "bear_test/bear_type/10/_explain?analyzer=some"
+  end
+
+  test ~S| urn("bear_test", "bear_type", "10", "/_explain", { %{analyzer: "some"} }) | do
+    actual = urn("bear_test", "bear_type", "10", "/_explain", { %{analyzer: "some"} })
+    assert actual == "bear_test/bear_type/10/_explain?analyzer=some"
+  end
+end


### PR DESCRIPTION
According to the main ES specs, https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/api and from basic reference, https://www.elastic.co/guide/en/elasticsearch/reference/current/indices.html

- [x] Deprecation notice for `Tirexs.Manage`

Index management:

- [x] Create Index
- [x] Delete Index
- [x] Get Index
- [x] Indices Exists
- [x] Open / Close Index API

Mapping Management:

- [x] Put Mapping
- [x] Get Mapping
- [x] Get Field Mapping
- [x] Types Exists

Index Settings:

- [x] Update Indices Settings
- [x] Get Settings
- [x] Analyze
- [x] Index Templates
- [x] Warmers

Status Management:

- [x] Clear Cache
- [x] Refresh
- [x] Flush
- [x] Force Merge
- [x] Upgrade

Alias management:

- [x] Index Aliases

Monitoring:

- [x] Indices Stats
- [x] Indices Segments
- [x] Indices Recovery
- [x] Indices Shard Stores

Replica configurations:

- [x] Shadow replica indices

Further scope:

_source
_count
_warmer
_percolate and .percolator
_bulk
_explain
_validate/query

`bump!` w/ `body`
```
create_resource_settings(definition, uri)
url  = "#{definition[:index]}/#{definition[:type]}/_mapping"
json = to_resource_json(definition)
HTTP.put(url, json, uri)
```
