### PR TITLE
Keyword list support for `:uri` env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,36 @@ An Elixir flavored DSL for building JSON based settings, mappings, queries, perc
 _Hint: Check out [/examples](/examples) directory as a quick intro._
 
 
+Configuration
+-------------------
+
+In your mix app, add this to your mix.exs:
+```elixir
+def deps do
+  [{:tirexs, "~> 0.7.6"}]
+end
+```
+To setup the elasticsearch url config, add this to dev.exs (or test/prod.exs/etc):
+```elixir
+# As a keyword list
+config :tirexs, :uri,
+  authority: "localhost:9200",
+  fragment: nil,
+  host: "localhost",
+  path: "/",
+  port: 9200,
+  query: nil,
+  scheme: "http",
+  userinfo: nil
+# Or as a URI struct
+config :tirexs, :uri, %URI{authority: "localhost:9200", fragment: nil,
+                           host: "localhost", path: "/", port: 9200,
+                           query: nil, scheme: "http", userinfo: nil}
+# Or as a full url string
+config :tirexs, :uri URI.parse("http://localhost:9200")
+```
+NOTE: it defaults to 127.0.0.1:9200 but it is recommended to set your config settings now. Good practice.
+
 Walk-through a code
 -------------------
 

--- a/lib/tirexs/elastic_search.ex
+++ b/lib/tirexs/elastic_search.ex
@@ -5,7 +5,14 @@ defmodule Tirexs.ElasticSearch do
   Get default URI for `ElasticSearch` connection. Returns the value from `Application.get_env(:tirexs, :uri)`.
   """
   def config do
-    Application.get_env(:tirexs, :uri)
+    uri = Application.get_env(:tirexs, :uri)
+    if Keyword.keyword?(uri) do
+      Enum.reduce uri, %URI{}, fn ({key, value}, uri_struct) ->
+        %{ uri_struct | key => value }
+      end
+    else
+      uri
+    end
   end
 
   @doc """


### PR DESCRIPTION
- Adds support for keyword list instead of URI struct. If you load from sys.config, it requires a strict, erlang data structure. You may be able to enter URI structs but keyword lists are easier to enter/read
- Add docs on mix deps (including version numbers)
- Add docs on elasticsearch config, including as a `%URI{}` struct and using `URI.parse`