### PR TITLE
`v0.8.0-beta3` release candidate

### DIFF
--- a/lib/tirexs.ex
+++ b/lib/tirexs.ex
@@ -50,4 +50,7 @@ defmodule Tirexs do
 
   """
   defdelegate [load_file(file), load_file(file, relative_to)], to: Code
+
+  @doc false
+  defdelegate [bump(), bump(uri), bump!(), bump!(uri)], to: Tirexs.Resources
 end

--- a/lib/tirexs/bulk.ex
+++ b/lib/tirexs/bulk.ex
@@ -5,11 +5,18 @@ defmodule Tirexs.Bulk do
 
 
   @doc false
-  defmacro store(options, settings, [do: block]) do
+  defmacro store(options, uri, [do: block]) do
     documents = extract_block(block)
     quote do
-      [documents, options, settings] = [unquote(documents), unquote(options), unquote(settings)]
-      bulk(documents, options, settings)
+      [documents, options, uri] = [unquote(documents), unquote(options), unquote(uri)]
+      bulk(documents, options, uri)
+    end
+  end
+
+  @doc false
+  defmacro store(options, [do: block]) do
+    quote do
+      store(unquote(options), Tirexs.get_uri_env(), [do: unquote(block)])
     end
   end
 

--- a/lib/tirexs/dsl.ex
+++ b/lib/tirexs/dsl.ex
@@ -7,7 +7,7 @@ defmodule Tirexs.DSL do
 
   @doc false
   def define(type, resource) do
-    elastic_settings = Tirexs.ElasticSearch.config()
+    elastic_settings = Tirexs.get_uri_env()
     case resource.(type, elastic_settings) do
       { type, elastic_settings } -> create_resource(type, elastic_settings)
     end
@@ -15,7 +15,7 @@ defmodule Tirexs.DSL do
 
   @doc false
   def define(resource) do
-    elastic_settings = Tirexs.ElasticSearch.config()
+    elastic_settings = Tirexs.get_uri_env()
     case resource.(elastic_settings) do
       { type, elastic_settings } -> create_resource(type, elastic_settings)
     end

--- a/lib/tirexs/elastic_search.ex
+++ b/lib/tirexs/elastic_search.ex
@@ -5,7 +5,7 @@ defmodule Tirexs.ElasticSearch do
   Get default URI for `ElasticSearch` connection. Returns the value from `Application.get_env(:tirexs, :uri)`.
   """
   def config do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.config/0` is deprecated, please use `Tirexs.get_uri_env/0` instead\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.config/0` is deprecated, please use `Tirexs.get_uri_env/0` instead\n" <> Exception.format_stacktrace
     Application.get_env(:tirexs, :uri)
   end
 
@@ -13,7 +13,7 @@ defmodule Tirexs.ElasticSearch do
   Set `ElasticSearch` connection from URL.
   """
   def config(url) when is_bitstring(url) do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.config/1` is deprecated, and will be removed\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.config/1` is deprecated, and will be removed\n" <> Exception.format_stacktrace
     URI.parse(url)
   end
 
@@ -22,61 +22,61 @@ defmodule Tirexs.ElasticSearch do
   Arguments must match those in Elixir's `URI` module.
   """
   def config(opts) when is_list(opts) do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.config/1` is deprecated, and will be removed\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.config/1` is deprecated, and will be removed\n" <> Exception.format_stacktrace
     Map.merge(config, Enum.into(opts, %{}))
   end
 
   @doc false
   def config(config, part) do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.config/1` is deprecated, and will be removed\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.config/1` is deprecated, and will be removed\n" <> Exception.format_stacktrace
     config[part]
   end
 
   @doc false
   def get(query_url, config) do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.get/2` is deprecated, please use `Tirexs.HTTP.get/2` instead\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.get/2` is deprecated, please use `Tirexs.HTTP.get/2` instead\n" <> Exception.format_stacktrace
     do_request(make_url(query_url, config), :get)
   end
 
   @doc false
   def put(query_url, config) do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.put/2` is deprecated, please use `Tirexs.HTTP.put/2` instead\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.put/2` is deprecated, please use `Tirexs.HTTP.put/2` instead\n" <> Exception.format_stacktrace
     put(query_url, [], config)
   end
 
   def put(query_url, body, config) do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.put/3` is deprecated, please use `Tirexs.HTTP.put/3` instead\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.put/3` is deprecated, please use `Tirexs.HTTP.put/3` instead\n" <> Exception.format_stacktrace
     unless body == [], do: body = to_string(body)
     do_request(make_url(query_url, config), :put, body)
   end
 
   @doc false
   def delete(query_url, config) do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.delete/2` is deprecated, please use `Tirexs.HTTP.delete/2` instead\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.delete/2` is deprecated, please use `Tirexs.HTTP.delete/2` instead\n" <> Exception.format_stacktrace
     delete(query_url, [], config)
   end
 
   @doc false
   def delete(query_url, body, config) do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.delete/3` is deprecated, please use `Tirexs.HTTP.delete/3` instead\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.delete/3` is deprecated, please use `Tirexs.HTTP.delete/3` instead\n" <> Exception.format_stacktrace
     unless body == [], do: body = to_string(body)
     do_request(make_url(query_url, config), :delete, body)
   end
 
   @doc false
   def head(query_url, config) do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.head/2` is deprecated, please use `Tirexs.HTTP.head/2` instead\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.head/2` is deprecated, please use `Tirexs.HTTP.head/2` instead\n" <> Exception.format_stacktrace
     do_request(make_url(query_url, config), :head)
   end
 
   @doc false
   def post(query_url, config) do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.post/2` is deprecated, please use `Tirexs.HTTP.post/2` instead\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.post/2` is deprecated, please use `Tirexs.HTTP.post/2` instead\n" <> Exception.format_stacktrace
     post(query_url, [], config)
   end
 
   def post(query_url, body, config) do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.post/3` is deprecated, please use `Tirexs.HTTP.post/3` instead\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.post/3` is deprecated, please use `Tirexs.HTTP.post/3` instead\n" <> Exception.format_stacktrace
     unless body == [], do: body = to_string(body)
     url = make_url(query_url, config)
     do_request(url, :post, body)
@@ -84,7 +84,7 @@ defmodule Tirexs.ElasticSearch do
 
   @doc false
   def exist?(url, settings) do
-    IO.write :stderr, "warning: `Tirexs.Elasticsearch.exist?/2` is deprecated, please use `Tirexs.HTTP.exist?/2` instead\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.exist?/2` is deprecated, please use `Tirexs.HTTP.exist?/2` instead\n" <> Exception.format_stacktrace
     case head(url, settings) do
       {:error, _, _} -> false
       _ -> true

--- a/lib/tirexs/elastic_search.ex
+++ b/lib/tirexs/elastic_search.ex
@@ -85,7 +85,7 @@ defmodule Tirexs.ElasticSearch do
 
   @doc false
   def exist?(url, settings) do
-    IO.write :stderr, "warning: `Tirexs.ElasticSearch.exist?/2` is deprecated, please use `Tirexs.HTTP.exist?/2` instead\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.exist?/2` is deprecated, please use `Tirexs.Resources.exists?/2` instead\n" <> Exception.format_stacktrace
     case head(url, settings) do
       {:error, _, _} -> false
       _ -> true

--- a/lib/tirexs/elastic_search.ex
+++ b/lib/tirexs/elastic_search.ex
@@ -1,4 +1,5 @@
 defmodule Tirexs.ElasticSearch do
+  @moduledoc "warning: This module is completely outdated and will be removed in `v0.8.0`"
 
 
   @doc """
@@ -13,7 +14,7 @@ defmodule Tirexs.ElasticSearch do
   Set `ElasticSearch` connection from URL.
   """
   def config(url) when is_bitstring(url) do
-    IO.write :stderr, "warning: `Tirexs.ElasticSearch.config/1` is deprecated, and will be removed\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.config/1` is deprecated, and will be removed. Please use `Tirexs.get_uri_env/0` instead.\n" <> Exception.format_stacktrace
     URI.parse(url)
   end
 
@@ -22,13 +23,13 @@ defmodule Tirexs.ElasticSearch do
   Arguments must match those in Elixir's `URI` module.
   """
   def config(opts) when is_list(opts) do
-    IO.write :stderr, "warning: `Tirexs.ElasticSearch.config/1` is deprecated, and will be removed\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.config/1` is deprecated, and will be removed. Please use `Tirexs.get_uri_env/0` instead.\n" <> Exception.format_stacktrace
     Map.merge(config, Enum.into(opts, %{}))
   end
 
   @doc false
   def config(config, part) do
-    IO.write :stderr, "warning: `Tirexs.ElasticSearch.config/1` is deprecated, and will be removed\n" <> Exception.format_stacktrace
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.config/1` is deprecated, and will be removed. Please use `Tirexs.get_uri_env/0` instead.\n" <> Exception.format_stacktrace
     config[part]
   end
 

--- a/lib/tirexs/elastic_search/settings.ex
+++ b/lib/tirexs/elastic_search/settings.ex
@@ -1,22 +1,19 @@
 defmodule Tirexs.ElasticSearch.Settings do
   @moduledoc false
 
-  import Tirexs.ElasticSearch
+  alias Tirexs.{Resources, HTTP}
 
 
   @doc false
-  def create_resource(definition) do
-    create_resource(definition, config())
-  end
-
-  @doc false
-  def create_resource(definition, opts) do
-    if exist?(definition[:index], opts), do: delete(definition[:index], opts)
-    post(definition[:index], to_resource_json(definition), opts)
+  def create_resource(definition, uri \\ Tirexs.get_uri_env()) do
+    if Resources.exists?(definition[:index], uri) do
+      HTTP.delete(definition[:index], uri)
+    end
+    HTTP.post(definition[:index], to_resource_json(definition), uri)
   end
 
   @doc false
   def to_resource_json(definition) do
-    Tirexs.HTTP.encode([settings: definition[:settings]])
+    HTTP.encode([settings: definition[:settings]])
   end
 end

--- a/lib/tirexs/manage.ex
+++ b/lib/tirexs/manage.ex
@@ -1,5 +1,5 @@
 defmodule Tirexs.Manage do
-  @moduledoc false
+  @moduledoc "warning: This module is completely outdated and will be removed in `v0.8.0`"
 
   import Tirexs.DSL.Logic
 
@@ -33,6 +33,7 @@ defmodule Tirexs.Manage do
 
   @doc false
   def aliases(aliases_params, settings) do
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.aliases/2` is deprecated, please use `Tirexs.Resources.APIs._aliases/2` instead\n" <> Exception.format_stacktrace
     Tirexs.ElasticSearch.post("_aliases", JSX.encode!(aliases_params), settings)
   end
 
@@ -55,11 +56,13 @@ defmodule Tirexs.Manage do
 
   @doc false
   def refresh(index, settings) when is_binary(index) do
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.refresh/2` is deprecated, please use `Tirexs.Resources.APIs._refresh/2` instead\n" <> Exception.format_stacktrace
     Tirexs.ElasticSearch.post(to_string(index) <> "/_refresh", settings)
   end
 
   @doc false
   def refresh(indexes, settings) when is_list(indexes) do
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.refresh/2` is deprecated, please use `Tirexs.Resources.APIs._refresh/2` instead\n" <> Exception.format_stacktrace
     indexes = Enum.join(indexes, ",")
     refresh(indexes, settings)
   end

--- a/lib/tirexs/mapping.ex
+++ b/lib/tirexs/mapping.ex
@@ -40,12 +40,12 @@ defmodule Tirexs.Mapping do
         if options[:do] != nil do
           block = options
           options = [type: "object"]
-          Dict.put([], to_atom(name), options ++ [properties: extract(block[:do])])
+          [ {to_atom(name), options ++ [properties: extract(block[:do])]} ]
         else
-          Dict.put([], to_atom(name), options)
+          [ {to_atom(name), options} ]
         end
       [name, options, block] ->
-        Dict.put([], to_atom(name), options ++ [properties: extract(block[:do])])
+        [ {to_atom(name), options ++ [properties: extract(block[:do])]} ]
     end
   end
 
@@ -86,17 +86,12 @@ defmodule Tirexs.Mapping do
 
   @doc false
   def to_resource_json(definition, type) do
-    resource =
-      # definition w/ mappings and settings
-      if definition[:settings] != nil do
-        mappings_dict = Dict.put([], to_atom(type), definition[:mapping])
-        resource = Dict.put([], to_atom("mappings"), mappings_dict)
-        resource = Dict.put(resource, to_atom("settings"), definition[:settings])
-      # definition just only w/ mapping
-      else
-        Dict.put([], to_atom(type), definition[:mapping])
-      end
-
-    HTTP.encode(resource)
+    # definition w/ mappings and settings
+    if definition[:settings] != nil do
+      [ {:mappings, [{to_atom(type), definition[:mapping]}]}, {:settings, definition[:settings]} ]
+    # definition just only w/ mapping
+    else
+      [ {to_atom(type), definition[:mapping]} ]
+    end
   end
 end

--- a/lib/tirexs/percolator.ex
+++ b/lib/tirexs/percolator.ex
@@ -2,6 +2,7 @@ defmodule Tirexs.Percolator do
   @moduledoc false
 
   use Tirexs.DSL.Logic
+  alias Tirexs.{HTTP}
 
 
   @doc false
@@ -35,11 +36,11 @@ defmodule Tirexs.Percolator do
   end
 
   @doc false
-  def create_resource(definition, settings) do
-    url  = "#{definition[:index]}/.percolator/#{definition[:name]}"
-    json = to_resource_json(definition)
+  def create_resource(definition, uri \\ Tirexs.get_uri_env()) do
+    path = "#{definition[:index]}/.percolator/#{definition[:name]}"
+    body = to_resource_json(definition)
 
-    Tirexs.ElasticSearch.put(url, json, settings)
+    HTTP.put(path, uri, body)
   end
 
   @doc false
@@ -47,14 +48,15 @@ defmodule Tirexs.Percolator do
     definition = Dict.delete(definition, :index)
     definition = Dict.delete(definition, :type)
     definition = Dict.delete(definition, :name)
-    Tirexs.HTTP.encode(definition)
+
+    HTTP.encode(definition)
   end
 
   @doc false
-  def match(definition, settings) do
-    url  = "#{definition[:index]}/#{definition[:type]}/_percolate"
-    json = to_resource_json(definition)
+  def match(definition, uri \\ Tirexs.get_uri_env()) do
+    path = "#{definition[:index]}/#{definition[:type]}/_percolate"
+    body = to_resource_json(definition)
 
-    Tirexs.ElasticSearch.post(url, json, settings)
+    HTTP.post(path, uri, body)
   end
 end

--- a/lib/tirexs/resources.ex
+++ b/lib/tirexs/resources.ex
@@ -1,0 +1,109 @@
+defmodule Tirexs.Resources do
+  @moduledoc """
+  The intend is to provide an abstraction for dealing with ES resources.
+
+  The interface of this module is aware about elasticsearch REST APIs conventions.
+  Meanwhile, a `Tirexs.HTTP` provides just a general interface.
+
+  """
+
+  import Tirexs.HTTP
+
+
+  @doc "the same as `ok?(head(path, uri))`"
+  def exists?(path, uri), do: ok?(head(path, uri))
+  def exists?(url_or_path_or_uri), do: ok?(head(url_or_path_or_uri))
+
+  @doc "the same as `head!(path, uri)`"
+  def exists!(path, uri), do: head!(path, uri)
+  def exists!(url_or_path_or_uri), do: head!(url_or_path_or_uri)
+
+  @doc """
+  Composes an URN from parts into request ready path as a binary string.
+
+  ## Examples:
+
+      iex> urn ["bear_test", "/_alias", ["2015", "2016"]]
+      "bear_test/_alias/2015,2016"
+
+      iex> urn [["bear_test", "another_bear_test"], "_refresh", { [ignore_unavailable: true] }]
+      "bear_test,another_bear_test/_refresh?ignore_unavailable=true"
+
+      iex> urn("bear_test", "bear_type", "10", "_explain?analyzer=some")
+      "bear_test/bear_type/10/_explain?analyzer=some"
+
+  """
+  def urn(part) when is_binary(part) do
+    normalize(part)
+  end
+  def urn(parts)  when is_list(parts) do
+    Enum.map(parts, fn(part) -> normalize(part) end) |> Enum.join("/") |> String.replace("/?", "?")
+  end
+  def urn(a, b), do: urn([a ,b])
+  def urn(a, b, c), do: urn([a,b,c])
+  def urn(a, b, c, d), do: urn([a,b,c,d])
+  def urn(a, b, c, d, e), do: urn([a,b,c,d,e])
+  def urn(a, b, c, d, e, f), do: urn([a,b,c,d,e,f])
+  def urn(a, b, c, d, e, f, g), do: urn([a,b,c,d,e,f,g])
+
+  @doc false
+  def normalize(resource) when is_binary(resource) do
+    String.strip(resource) |> String.replace_prefix("/", "")
+  end
+  def normalize({ params }) do
+    "?" <> URI.encode_query(params)
+  end
+  def normalize(resource) do
+    pluralize(resource) |> normalize()
+  end
+
+  @doc false
+  def pluralize(resource) when is_binary(resource), do: resource
+  def pluralize(resource), do: Enum.join(resource, ",")
+
+  @doc """
+  Tries to bump resource. This one just makes a request and behaves like a proxy to
+  one of avalable resource helper. You're able to bump any resources which are defined in
+  `Tirexs.Resources.APIs`.
+
+  Let's consider the following use case:
+
+      iex> path = Tirexs.Resources.APIs._refresh(["bear_test", "duck_test"], { [force: false] })
+      "bear_test,duck_test/_refresh?force=false"
+
+      iex> Tirexs.HTTP.post(path)
+      { :ok, 200, ... }
+
+  With bump, the same is:
+
+      iex> bump._refresh(["bear_test", "duck_test"], { [force: false] })
+      { :ok, 200, ... }
+
+  Play with resources you have and see what kind of HTTP verb is used.
+
+  """
+  def bump(), do: __t(:bump)
+  def bump(uri), do: __t(:bump, uri)
+  def bump!(), do: __t(:bump!)
+  def bump!(uri), do: __t(:bump!, uri)
+
+
+  @doc false
+  def __c(urn, meta) do
+    if ctx = Process.delete(:tirexs_resources_chain) do
+      args = case urn do
+        urn when is_binary(urn) -> [ urn, ctx[:uri] ]
+        [ urn, body ]           -> [ urn, ctx[:uri], body ]
+      end
+      Kernel.apply(Tirexs.HTTP, meta[ctx[:label]], args)
+    else
+      urn
+    end
+  end
+
+  @doc false
+  defp __t(label, uri \\ Tirexs.ENV.get_uri_env()) do
+    Process.put(:tirexs_resources_chain, [label: label, uri: uri])
+    Tirexs.Resources.APIs
+  end
+end

--- a/lib/tirexs/resources/apis.ex
+++ b/lib/tirexs/resources/apis.ex
@@ -1,0 +1,85 @@
+defmodule Tirexs.Resources.APIs do
+  @moduledoc """
+  This module provides a set of API helpers. Helpers are useful for buiding
+  an URN part of particular request. Most commonly the result of this would
+  be used for dealing directly with variety of available `Tirexs.HTTP` functions.
+
+  ## Examples:
+
+      iex> APIs._refresh({ [force: true] })
+      "_refresh?force=true"
+
+      iex> APIs._refresh(["bear_test", "duck_test"], { [force: false] })
+      "bear_test,duck_test/_refresh?force=false"
+
+      iex> APIs._field_mapping(["bear_test", "duck_test"], "message", {[ ignore_unavailable: true ]})
+      "bear_test,duck_test/_mapping/message/field?ignore_unavailable=true"
+
+      iex> APIs._field_mapping("_all", "tw*", ["*.id", "*.text"])
+      "_all/_mapping/tw*/field/*.id,*.text"
+
+  NOTICE: All of helpers have the same interface, behaviour and almost don't care about the details.
+  It means, you have a chance to create a complety unsupported API call.
+
+  ## For instance:
+
+      iex> APIs._refresh(["bear_test", "duck_test"], ["a", "b"], {[ human: true ]})
+      "bear_test,duck_test/_refresh/a,b?human=true"
+
+
+  A `Tirexs.Resources.urn/x` is responsible for concatenation parts all together.
+
+  ## Feature requests
+
+  Feature requests are welcome and should be discussed. But take a moment to find
+  out whether your idea fits with the scope and aims of the project. Please provide
+  as much detail and context as possible (from `CONTRIBUTING.md`).
+
+  """
+
+  alias Tirexs.Resources.Indicies
+
+
+  ## Mapping Management
+
+  @doc false
+  defdelegate [ _all_mapping() ], to: Indicies
+  defdelegate [ _mapping(), _mapping(a), _mapping(a, b), _mapping(a, b, c) ], to: Indicies
+  defdelegate [ _field_mapping(a), _field_mapping(a, b), _field_mapping(a, b, c),  _field_mapping(a, b, c)], to: Indicies
+
+  ## Index Settings
+
+  @doc false
+  defdelegate [ _analyze(), _analyze(a), _analyze(a, b), _analyze(a, b, c) ], to: Indicies
+  defdelegate [ _warmer(), _warmer(a), _warmer(a, b), _warmer(a, b, c) ], to: Indicies
+  defdelegate [ _template(), _template(a), _template(a, b), _template(a, b, c) ], to: Indicies
+  defdelegate [ _settings(), _settings(a), _settings(a, b), _settings(a, b, c) ], to: Indicies
+
+  ## Index Management
+
+  @doc false
+  defdelegate [ _open(), _open(a), _open(a, b), _open(a, b, c) ], to: Indicies
+  defdelegate [ _close(), _close(a), _close(a, b), _close(a, b, c) ], to: Indicies
+  ## Alias Management
+
+  @doc false
+  defdelegate [ _aliases(), _aliases(a), _aliases(a, b), _aliases(a, b, c) ], to: Indicies
+  defdelegate [ _alias(), _alias(a), _alias(a, b), _alias(a, b, c) ], to: Indicies
+
+  ## Status Management
+
+  @doc false
+  defdelegate [ _refresh(), _refresh(a), _refresh(a, b), _refresh(a, b, c) ], to: Indicies
+  defdelegate [ _flush(), _flush(a), _flush(a, b), _flush(a, b, c) ], to: Indicies
+  defdelegate [ _forcemerge(), _forcemerge(a), _forcemerge(a, b), _forcemerge(a, b, c) ], to: Indicies
+  defdelegate [ _upgrade(), _upgrade(a), _upgrade(a, b), _upgrade(a, b, c) ], to: Indicies
+  defdelegate [ _cache_clear(), _cache_clear(a), _cache_clear(a, b), _cache_clear(a, b, c) ], to: Indicies
+
+  ## Monitoring Management
+
+  @doc false
+  defdelegate [ _stats(), _stats(a), _stats(a, b), _stats(a, b, c) ], to: Indicies
+  defdelegate [ _segments(), _segments(a), _segments(a, b), _segments(a, b, c) ], to: Indicies
+  defdelegate [ _recovery(), _recovery(a), _recovery(a, b), _recovery(a, b, c) ], to: Indicies
+  defdelegate [ _shard_stores(), _shard_stores(a), _shard_stores(a, b), _shard_stores(a, b, c) ], to: Indicies
+end

--- a/lib/tirexs/resources/indicies.ex
+++ b/lib/tirexs/resources/indicies.ex
@@ -1,0 +1,184 @@
+defmodule Tirexs.Resources.Indicies do
+  @moduledoc """
+  Provides URN builders for indices APIs.
+
+  `Tirexs.Resources.APIs` describes the main interface and available options.
+
+  The indices APIs are used to manage individual indices, index settings, aliases, mappings, index templates and warmers.
+
+  """
+
+  import Tirexs.Resources, only: [urn: 1, urn: 2, urn: 3, urn: 4, __c: 2]
+
+
+  ## Mapping Management
+
+  @doc false
+  @r [action: "/_mapping", bump: :put, bump!: :put!]
+  def _mapping(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _mapping(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _mapping({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _mapping(a), do: __c(urn(a, @r[:action]), @r)
+  def _mapping(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  def _all_mapping(), do: _mapping("_all")
+
+  @doc false
+  @r [action: "/_mapping/field", bump: :get, bump!: :get!]
+  def _field_mapping(a, b, c, {d}), do: __c(urn([a, "_mapping", b, "field", c, {d}]), @r)
+  def _field_mapping(a, b, c), do: __c(urn([a, "_mapping", b, "field", c]), @r)
+  def _field_mapping(a, {b}), do: __c(urn(@r[:action], a, {b}), @r)
+  def _field_mapping(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _field_mapping(a), do: __c(urn(a, @r[:action]), @r)
+
+
+  ## Index Settings
+
+  @doc false
+  @r [action: "/_analyze", bump: :get, bump!: :get!]
+  def _analyze(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _analyze(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _analyze({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _analyze(a), do: __c(urn(a, @r[:action]), @r)
+  def _analyze(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_warmer", bump: :put, bump!: :put!]
+  def _warmer(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _warmer(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _warmer({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _warmer(a), do: __c(urn(a, @r[:action]), @r)
+  def _warmer(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_template", bump: :put, bump!: :put!]
+  def _template(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _template(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _template({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _template(a), do: __c(urn(a, @r[:action]), @r)
+  def _template(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_settings", bump: :get, bump!: :get!]
+  def _settings(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _settings(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _settings({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _settings(a), do: __c(urn(a, @r[:action]), @r)
+  def _settings(), do: __c(urn(@r[:action]), @r)
+
+
+  ## Index Management
+
+  @doc false
+  @r [action: "/_open", bump: :post, bump!: :post!]
+  def _open(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _open(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _open({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _open(a), do: __c(urn(a, @r[:action]), @r)
+  def _open(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_close", bump: :post, bump!: :post!]
+  def _close(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _close(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _close({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _close(a), do: __c(urn(a, @r[:action]), @r)
+  def _close(), do: __c(urn(@r[:action]), @r)
+
+
+  ## Alias Management
+
+  @doc false
+  @r [action: "/_aliases"]
+  def _aliases(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _aliases(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _aliases({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _aliases(a), do: __c(urn(a, @r[:action]), @r)
+  def _aliases(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_alias", bump: :put, bump!: :put!]
+  def _alias(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _alias(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _alias({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _alias(a), do: __c(urn(a, @r[:action]), @r)
+  def _alias(), do: __c(urn(@r[:action]), @r)
+
+
+  ## Status Management
+
+  @doc false
+  @r [action: "/_refresh", bump: :post, bump!: :post!]
+  def _refresh(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _refresh(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _refresh({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _refresh(a), do: __c(urn(a, @r[:action]), @r)
+  def _refresh(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_flush", bump: :post, bump!: :post!]
+  def _flush(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _flush(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _flush({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _flush(a), do: __c(urn(a, @r[:action]), @r)
+  def _flush(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_forcemerge", bump: :post, bump!: :post!]
+  def _forcemerge(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _forcemerge(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _forcemerge({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _forcemerge(a), do: __c(urn(a, @r[:action]), @r)
+  def _forcemerge(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_upgrade", bump: :post, bump!: :post!]
+  def _upgrade(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _upgrade(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _upgrade({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _upgrade(a), do: __c(urn(a, @r[:action]), @r)
+  def _upgrade(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_cache/clear", bump: :post, bump!: :post!]
+  def _cache_clear(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _cache_clear({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _cache_clear(a), do: __c(urn(a, @r[:action]), @r)
+  def _cache_clear(), do: __c(urn(@r[:action]), @r)
+
+
+  ## Monitoring Management
+
+  @doc false
+  @r [action: "/_stats", bump: :get, bump!: :get!]
+  def _stats(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _stats(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _stats({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _stats(a), do: __c(urn(a, @r[:action]), @r)
+  def _stats(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_segments", bump: :get, bump!: :get!]
+  def _segments(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _segments(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _segments({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _segments(a), do: __c(urn(a, @r[:action]), @r)
+  def _segments(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_recovery", bump: :get, bump!: :get!]
+  def _recovery(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _recovery(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _recovery({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _recovery(a), do: __c(urn(a, @r[:action]), @r)
+  def _recovery(), do: __c(urn(@r[:action]), @r)
+
+  @doc false
+  @r [action: "/_shard_stores", bump: :get, bump!: :get!]
+  def _shard_stores(a, b, c), do: __c(urn(a, @r[:action], b, c), @r)
+  def _shard_stores(a, b), do: __c(urn(a, @r[:action], b), @r)
+  def _shard_stores({a}), do: __c(urn(@r[:action], {a}), @r)
+  def _shard_stores(a), do: __c(urn(a, @r[:action]), @r)
+  def _shard_stores(), do: __c(urn(@r[:action]), @r)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Tirexs.Mixfile do
   use Mix.Project
 
   def project do
-    [ app: :tirexs, version: "0.8.0-beta2", elixir: "~> 1.2.0", description: description, package: package, deps: deps ]
+    [ app: :tirexs, version: "0.8.0-beta3", elixir: "~> 1.2.0", description: description, package: package, deps: deps ]
   end
 
   def application do

--- a/test/acceptances/examples_test.exs
+++ b/test/acceptances/examples_test.exs
@@ -8,17 +8,17 @@ defmodule Acceptances.ExamplesTest do
 
   test ~S(loads "examples/mapping.exs") do
     Path.expand("examples/mapping.exs") |> Tirexs.load_file
-    Tirexs.HTTP.head!("bear_test")
+    Tirexs.Resources.exists!("bear_test")
   end
 
   test ~S(loads "examples/mapping_with_settings.exs") do
     Path.expand("examples/mapping_with_settings.exs") |> Tirexs.load_file
-    Tirexs.HTTP.head!("bear_test")
+    Tirexs.Resources.exists!("bear_test")
   end
 
   test ~S(loads "examples/settings.exs") do
     Path.expand("examples/settings.exs") |> Tirexs.load_file
-    Tirexs.HTTP.head!("bear_test")
+    Tirexs.Resources.exists!("bear_test")
   end
 
   test ~S(loads "examples/search.exs") do

--- a/test/acceptances/mapping_test.exs
+++ b/test/acceptances/mapping_test.exs
@@ -1,18 +1,13 @@
-Code.require_file "../../test_helper.exs", __ENV__.file
-
 defmodule Acceptances.MappingTest do
   use ExUnit.Case
 
+  use Tirexs.Mapping
+  alias Tirexs.{HTTP, Resources}
 
-  alias Tirexs.{ElasticSearch, Manage}
 
   setup_all do
-    ElasticSearch.delete("bear_test", ElasticSearch.config())
-    :ok
+    HTTP.delete("bear_test") && :ok
   end
-
-
-  use Tirexs.Mapping
 
   test "mappings definition (basic)" do
     index = [index: "bear_test", type: "bear_type"]
@@ -42,8 +37,7 @@ defmodule Acceptances.MappingTest do
   end
 
   test "create mapping and settings" do
-    es_settings = ElasticSearch.config()
-    ElasticSearch.delete("articles", es_settings)
+    HTTP.delete("articles")
 
     index = [index: "articles", type: "article"]
     settings do
@@ -69,9 +63,9 @@ defmodule Acceptances.MappingTest do
 
     Tirexs.Mapping.create_resource(index)
 
-    Manage.refresh("articles", es_settings)
+    Resources.bump!._refresh("articles")
 
-    {:ok, 200, response} = ElasticSearch.get("articles", es_settings)
+    {:ok, 200, response} = HTTP.get("articles")
 
     settings = response[:articles][:settings]
     mappings = response[:articles][:mappings]

--- a/test/acceptances/percolator_test.exs
+++ b/test/acceptances/percolator_test.exs
@@ -1,15 +1,16 @@
-Code.require_file "../../test_helper.exs", __ENV__.file
 defmodule Tirexs.PercolatorTest do
   use ExUnit.Case
+
   import Tirexs.Bulk
   import Tirexs.Percolator
-  require Tirexs.ElasticSearch
+
+  alias Tirexs.{HTTP, Percolator}
+
 
   test :percolator do
-    settings = Tirexs.ElasticSearch.config()
-    Tirexs.ElasticSearch.delete("my-index/.percolator/1", settings)
+    HTTP.delete("my-index/.percolator/1")
 
-    Tirexs.Bulk.store [index: "my-index", refresh: false], settings do
+    Tirexs.Bulk.store [index: "my-index", refresh: false] do
       create id: 1, message: "foo bar test"
       create id: 2, message: "bar bar test"
       create id: 3, message: "Old bonsai tree is down"
@@ -21,7 +22,7 @@ defmodule Tirexs.PercolatorTest do
       end
     end
 
-    {_, _, body} = Tirexs.Percolator.create_resource(percolator, settings)
+    {_, _, body} = Percolator.create_resource(percolator)
 
     assert body[:created]
     assert body[:_id]   == "1"
@@ -32,7 +33,7 @@ defmodule Tirexs.PercolatorTest do
       end
     end
 
-    {_, _, body} = Tirexs.Percolator.match(percolator, settings)
+    {_, _, body} = Percolator.match(percolator)
 
     assert body[:total] == 1
   end

--- a/test/acceptances/resources/indicies_test.exs
+++ b/test/acceptances/resources/indicies_test.exs
@@ -1,0 +1,37 @@
+defmodule Acceptances.Resources.IndiciesTest do
+  use ExUnit.Case
+
+  alias Tirexs.{HTTP, Resources}
+
+
+  setup do
+    HTTP.delete("bear_test") && :ok
+  end
+
+
+  test "_refresh/1" do
+    { :ok, 200, _ } = HTTP.put("bear_test")
+    { :ok, 200, _ } = Resources.bump._refresh("bear_test")
+  end
+
+  test "tries _refresh/1" do
+    { :error, 404, _ } = Resources.bump._refresh("unknown")
+  end
+
+  test "tries _refresh!/1" do
+    assert_raise(RuntimeError, fn -> Resources.bump!._refresh("unknown") end)
+  end
+
+  test "_flush/1" do
+    { :ok, 200, _ } = HTTP.put("bear_test")
+    { :ok, 200, _ } = Resources.bump._flush("bear_test")
+  end
+
+  test "tries _flush/1" do
+    { :error, 404, _ } = Resources.bump._flush("unknown")
+  end
+
+  test "tries _flush!/1" do
+    assert_raise(RuntimeError, fn -> Resources.bump!._flush("unknown") end)
+  end
+end

--- a/test/acceptances/resources_test.exs
+++ b/test/acceptances/resources_test.exs
@@ -1,0 +1,29 @@
+defmodule Acceptances.ResourcesTest do
+  use ExUnit.Case
+
+  alias Tirexs.{HTTP, Resources}
+
+
+  setup do
+    HTTP.delete("bear_test") && :ok
+  end
+
+
+  test "exists?/1" do
+    { :ok, 200, _ } = HTTP.put("bear_test")
+    assert Resources.exists?("bear_test")
+  end
+
+  test "tries exists?/1" do
+    refute Resources.exists?("unknown")
+  end
+
+  test "exists!/1" do
+    { :ok, 200, _ } = HTTP.put("bear_test")
+    assert Resources.exists!("bear_test")
+  end
+
+  test "tries exists!/1" do
+    assert_raise(RuntimeError, fn -> Resources.exists!("unknown") end)
+  end
+end

--- a/test/tirexs/resources/indicies_test.exs
+++ b/test/tirexs/resources/indicies_test.exs
@@ -1,0 +1,131 @@
+defmodule Tirexs.Resources.IndiciesTest do
+  use ExUnit.Case
+
+  alias Tirexs.Resources.Indicies
+
+
+  @resources [
+    "_refresh", "_flush", "_forcemerge", "_upgrade", "_alias", "_aliases",
+    "_stats", "_segments", "_recovery", "_shard_stores", "_close", "_open",
+    "_analyze", "_warmer", "_template", "_settings",
+    "_mapping"
+  ]
+
+  test ~S/functions like a '_refresh()'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh()
+      actual = Kernel.apply(Indicies, String.to_atom(resource), [])
+      assert actual == "#{resource}"
+    end
+  end
+
+  test ~S/functions like a '_refresh({ [local: true] })'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh({ [local: true] })
+      actual = Kernel.apply(Indicies, String.to_atom(resource), [{ [local: true] }])
+      assert actual == "#{resource}?local=true"
+    end
+  end
+
+  test ~S/functions like a '_refresh({ %{local: true} })'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh({ %{local: true} })
+      actual = Kernel.apply(Indicies, String.to_atom(resource), [{ %{local: true} }])
+      assert actual == "#{resource}?local=true"
+    end
+  end
+
+  test ~S/functions like a '_refresh("bear_test")'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh("bear_test")
+      actual = Kernel.apply(Indicies, String.to_atom(resource), ["bear_test"])
+      assert actual == "bear_test/#{resource}"
+    end
+  end
+
+  test ~S/functions like a '_refresh("bear_test", { [local: false] })'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh("bear_test", { [local: false] })
+      actual = Kernel.apply(Indicies, String.to_atom(resource), ["bear_test", { [local: false] }])
+      assert actual == "bear_test/#{resource}?local=false"
+    end
+  end
+
+  test ~S/functions like a '_refresh(["bear_test", "duck_test"])'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh(["bear_test", "duck_test"])
+      actual = Kernel.apply(Indicies, String.to_atom(resource), [["bear_test", "duck_test"]])
+      assert actual == "bear_test,duck_test/#{resource}"
+    end
+  end
+
+  test ~S/functions like a '_refresh(["bear_test", "duck_test"], { [local: false] })'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh(["bear_test", "duck_test"], { [local: false] })
+      actual = Kernel.apply(Indicies, String.to_atom(resource), [["bear_test", "duck_test"], { [local: false] }])
+      assert actual == "bear_test,duck_test/#{resource}?local=false"
+    end
+  end
+
+  test ~S/functions like a '_refresh("bear_test", "2015")'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh("bear_test", "2015")
+      actual = Kernel.apply(Indicies, String.to_atom(resource), ["bear_test", "2015"])
+      assert actual == "bear_test/#{resource}/2015"
+    end
+  end
+
+  test ~S/functions like a '_refresh(["bear_test", "duck_test"], "2015")'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh(["bear_test", "duck_test"], "2015")
+      actual = Kernel.apply(Indicies, String.to_atom(resource), [["bear_test", "duck_test"], "2015"])
+      assert actual == "bear_test,duck_test/#{resource}/2015"
+    end
+  end
+
+  test ~S/functions like a '_refresh("bear_test", "2015", { [local: true] })'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh("bear_test", "2015", { [local: true] })
+      actual = Kernel.apply(Indicies, String.to_atom(resource), ["bear_test", "2015", { [local: true] }])
+      assert actual == "bear_test/#{resource}/2015?local=true"
+    end
+  end
+
+  test ~S/functions like a '_refresh("bear_test", "2015", { %{local: true} })'/ do
+    Enum.each @resources, fn(resource) ->
+      # actual = Indicies._refresh("bear_test", "2015", { %{local: true} })
+      actual = Kernel.apply(Indicies, String.to_atom(resource), ["bear_test", "2015", { %{local: true} }])
+      assert actual == "bear_test/#{resource}/2015?local=true"
+    end
+  end
+
+  test ~S/functions like a '_cache_clear()'/ do
+    actual = Indicies._cache_clear()
+    assert actual == "_cache/clear"
+  end
+
+  test ~S/functions like a '_all_mapping()'/ do
+    actual = Indicies._all_mapping()
+    assert actual == "_all/_mapping"
+  end
+
+  test ~S/functions like a '_cache_clear(["bear_test", "duck_test"])'/ do
+    actual = Indicies._cache_clear(["bear_test", "duck_test"])
+    assert actual == "bear_test,duck_test/_cache/clear"
+  end
+
+  test ~S/functions like a '_field_mapping(["bear_test", "duck_test"])'/ do
+    actual = Indicies._field_mapping(["bear_test", "duck_test"])
+    assert actual == "bear_test,duck_test/_mapping/field"
+  end
+
+  test ~S/functions like a '_field_mapping(["bear_test", "duck_test"], "message")'/ do
+    actual = Indicies._field_mapping(["bear_test", "duck_test"], "message")
+    assert actual == "bear_test,duck_test/_mapping/field/message"
+  end
+
+  test ~S/functions like a '_field_mapping("_all", "tw*", "*.id")'/ do
+    actual = Indicies._field_mapping("_all", "tw*", "*.id")
+    assert actual == "_all/_mapping/tw*/field/*.id"
+  end
+end

--- a/test/tirexs/resources_test.exs
+++ b/test/tirexs/resources_test.exs
@@ -1,0 +1,142 @@
+defmodule Tirexs.ResourcesTest do
+  use ExUnit.Case
+
+  # alias Tirexs.{HTTP, Resources}
+  import Tirexs.Resources
+
+
+  test "urn/1" do
+    actual = urn("/_refresh")
+    assert actual == "_refresh"
+  end
+
+  test "urn/1 with params as string" do
+    actual = urn("_upgrade?wait_for_completion=true")
+    assert actual == "_upgrade?wait_for_completion=true"
+  end
+
+  test "urn/2 with params as list" do
+    actual = urn("/_upgrade", { [wait_for_completion: true] })
+    assert actual == "_upgrade?wait_for_completion=true"
+  end
+
+  test "urn/2 with params as map" do
+    actual = urn("/_upgrade", { %{wait_for_completion: true} })
+    assert actual == "_upgrade?wait_for_completion=true"
+  end
+
+  test "urn/2 as string" do
+    actual = urn("bear_test", "/_refresh")
+    assert actual == "bear_test/_refresh"
+  end
+
+  test "urn/2 as string with params as string" do
+    actual = urn("bear_test", "/_refresh?ignore_unavailable=true")
+    assert actual == "bear_test/_refresh?ignore_unavailable=true"
+  end
+
+  test "urn/3 as string with params as list" do
+    actual = urn("bear_test", "/_refresh", { [ignore_unavailable: true] })
+    assert actual == "bear_test/_refresh?ignore_unavailable=true"
+  end
+
+  test "urn/3 as string with params as map" do
+    actual = urn("bear_test", "/_refresh", { %{ignore_unavailable: true} })
+    assert actual == "bear_test/_refresh?ignore_unavailable=true"
+  end
+
+  test "urn/2 as list" do
+    actual = urn(["bear_test", "another_bear_test"], "/_refresh")
+    assert actual == "bear_test,another_bear_test/_refresh"
+  end
+
+  test "urn/3 as list with params as list" do
+    actual = urn(["bear_test", "another_bear_test"], "/_refresh", { [ignore_unavailable: true] })
+    assert actual == "bear_test,another_bear_test/_refresh?ignore_unavailable=true"
+  end
+
+  test "urn/3 as list with params as map" do
+    actual = urn(["bear_test", "another_bear_test"], "/_refresh", { %{ignore_unavailable: true} })
+    assert actual == "bear_test,another_bear_test/_refresh?ignore_unavailable=true"
+  end
+
+  test "urn/3 as string and name part as string" do
+    actual = urn("bear_test", "/_alias", "2015")
+    assert actual == "bear_test/_alias/2015"
+  end
+
+  test "urn/3 as string and name part as string with params as list" do
+    actual = urn("bear_test", "/_alias", "2015", { [local: true] })
+    assert actual == "bear_test/_alias/2015?local=true"
+  end
+
+  test "urn/3 as string and name part as string with params as map" do
+    actual = urn("bear_test", "/_alias", "2015", { %{local: true} })
+    assert actual == "bear_test/_alias/2015?local=true"
+  end
+
+  test "urn/3 as string and name part as a list" do
+    actual = urn("bear_test", "/_alias", ["2015", "2016"])
+    assert actual == "bear_test/_alias/2015,2016"
+  end
+
+  test "urn/3 as string and name part as a list with params list" do
+    actual = urn("bear_test", "/_alias", ["2015", "2016"], { [local: true] })
+    assert actual == "bear_test/_alias/2015,2016?local=true"
+  end
+
+  test "urn/3 as string and name part as a list with params map" do
+    actual = urn("bear_test", "/_alias", ["2015", "2016"], { %{local: true} })
+    assert actual == "bear_test/_alias/2015,2016?local=true"
+  end
+
+  test "urn/3 as list and string" do
+    actual = urn(["bear_test", "another_bear_test"], "/_alias", "2015")
+    assert actual == "bear_test,another_bear_test/_alias/2015"
+  end
+
+  test "urn/3 as list and name part as string with params as list" do
+    actual = urn(["bear_test", "another_bear_test"], "/_alias", "2015", { [local: true] })
+    assert actual == "bear_test,another_bear_test/_alias/2015?local=true"
+  end
+
+  test "urn/3 as list and name part as string with params as map" do
+    actual = urn(["bear_test", "another_bear_test"], "/_alias", "2015", { %{local: true} })
+    assert actual == "bear_test,another_bear_test/_alias/2015?local=true"
+  end
+
+  test "urn/3 as list and list" do
+    actual = urn(["bear_test", "another_bear_test"], "/_alias", ["2015", "2016"])
+    assert actual == "bear_test,another_bear_test/_alias/2015,2016"
+  end
+
+  test "urn/3 as list and name part as list with params as list" do
+    actual = urn(["bear_test", "another_bear_test"], "/_alias", ["2015", "2016"], { [local: true] })
+    assert actual == "bear_test,another_bear_test/_alias/2015,2016?local=true"
+  end
+
+  test "urn/3 as list and name part as list with params as map" do
+    actual = urn(["bear_test", "another_bear_test"], "/_alias", ["2015", "2016"], { %{local: true} })
+    assert actual == "bear_test,another_bear_test/_alias/2015,2016?local=true"
+  end
+
+  test ~S| urn("bear_test", "bear_type", "10", "/_explain") | do
+    actual = urn("bear_test", "bear_type", "10", "/_explain")
+    assert actual == "bear_test/bear_type/10/_explain"
+  end
+
+  test ~S| urn("bear_test", "bear_type", "10", "/_explain?analyzer=some") | do
+    actual = urn("bear_test", "bear_type", "10", "/_explain?analyzer=some")
+    assert actual == "bear_test/bear_type/10/_explain?analyzer=some"
+  end
+
+  test ~S| urn("bear_test", "bear_type", "10", "/_explain", { [analyzer: "some"] }) | do
+    actual = urn("bear_test", "bear_type", "10", "/_explain", { [analyzer: "some"] })
+    assert actual == "bear_test/bear_type/10/_explain?analyzer=some"
+  end
+
+  test ~S| urn("bear_test", "bear_type", "10", "/_explain", { %{analyzer: "some"} }) | do
+    actual = urn("bear_test", "bear_type", "10", "/_explain", { %{analyzer: "some"} })
+    assert actual == "bear_test/bear_type/10/_explain?analyzer=some"
+  end
+end


### PR DESCRIPTION
Scope:

- [x] `Tirexs.Resources` - an abstraction for dealing with ES resources (rebasing certain responsibilities between `Tirexs.ElasticSearch` and `Tirexs.Manage` modules), #182 
- [x] `Tirexs.Resources.APIs` - a set of API helpers, #182
- [x] `Tirexs.Resources.Indicies` - provides URN builders for indices APIs, #182
- [x] `Tirexs.Resources.bump` - makes a request and behaves like a proxy to
  one of avalable resource helper, #182
- [x] `Tirexs.Bulk.store/1` - using a `get_uri_env/0` (by default)
- [x] `Tirexs.Mapping.create_resource/1` - using a `get_uri_env/0` (by default)
- [x] `Tirexs.Percolator.create_resource/1, match/1` - using a `get_uri_env/0` (by default)
- [x] First-class details over `@moduledoc`, #12
- [x] warning: `Tirexs.Elasticsearch.refresh/2` is deprecated, please use `Tirexs.Resources.APIs._refresh/2` instead
- [x] warning: `Tirexs.Elasticsearch.aliases/2` is deprecated, please use `Tirexs.Resources.APIs._aliases/2` instead
- [ ] Aggregation in favor of Facets, #183
- [x] warning: `Tirexs.ElasticSearch.exist?/2` is deprecated, please use `Tirexs.Resources.exists?/2` instead 
- [ ] warning: `Tirexs.Elasticsearch.delete/3` is deprecated, please use `Tirexs.HTTP.delete/3` instead
- [x] warning: `Tirexs.Elasticsearch.config/0` is deprecated, please use `Tirexs.get_uri_env/0` instead
- [ ] warning: `Tirexs.Elasticsearch.post/3` is deprecated, please use `Tirexs.HTTP.post/3` instead
- [ ] warning: `Tirexs.Elasticsearch.get/2` is deprecated, please use `Tirexs.HTTP.get/2` instead
- [ ] warning: `Tirexs.Elasticsearch.put/3` is deprecated, please use `Tirexs.HTTP.put/3` instead
- [x] warning: `Tirexs.Elasticsearch.head/2` is deprecated, please use `Tirexs.HTTP.head/2` instead