### PR TITLE
`Tirexs.Resources` module

### DIFF
--- a/lib/tirexs/manage.ex
+++ b/lib/tirexs/manage.ex
@@ -23,11 +23,13 @@ defmodule Tirexs.Manage do
 
   @doc false
   def validate(options, settings) do
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.validate/2` is deprecated, please use `Tirexs.Resources.APIs._validate_query/2` instead\n" <> Exception.format_stacktrace
     execute_get_if_body_empty_and_post_otherwise("_validate/query", options, settings)
   end
 
   @doc false
   def explain(options, settings) do
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.explain/2` is deprecated, please use `Tirexs.Resources.APIs._explain/2` instead\n" <> Exception.format_stacktrace
     Tirexs.ElasticSearch.get(make_url("_explain", options), settings)
   end
 

--- a/lib/tirexs/manage.ex
+++ b/lib/tirexs/manage.ex
@@ -6,6 +6,7 @@ defmodule Tirexs.Manage do
 
   @doc false
   def count(options, settings) do
+    IO.write :stderr, "warning: `Tirexs.ElasticSearch.count/2` is deprecated, please use `Tirexs.Resources.APIs._count/2` instead\n" <> Exception.format_stacktrace
     execute_get_if_body_empty_and_post_otherwise("_count", options, settings)
   end
 

--- a/lib/tirexs/query.ex
+++ b/lib/tirexs/query.ex
@@ -419,6 +419,7 @@ defmodule Tirexs.Query do
       "#{definition[:index]}"
     end
 
+    IO.write :stderr, "warning: `/_search` is deprecated, please use `Tirexs.Resources.APIs._search/2` instead\n" <> Exception.format_stacktrace
     { url, json } = { "#{url}/_search" <> to_param(opts, ""), to_resource_json(definition) }
     case Tirexs.ElasticSearch.post(url, json, settings) do
       {:ok, _, result} ->

--- a/lib/tirexs/resources.ex
+++ b/lib/tirexs/resources.ex
@@ -83,17 +83,20 @@ defmodule Tirexs.Resources do
 
   """
   def bump(), do: __t(:bump)
-  def bump(uri), do: __t(:bump, uri)
+  def bump(%URI{} = uri), do: __t(:bump, [], uri)
+  def bump(body), do: __t(:bump, body)
+  def bump(body, %URI{} = uri), do: __t(:bump, body, uri)
   def bump!(), do: __t(:bump!)
-  def bump!(uri), do: __t(:bump!, uri)
+  def bump!(%URI{} = uri), do: __t(:bump!, [], uri)
+  def bump!(body), do: __t(:bump!, body)
+  def bump!(body, %URI{} = uri), do: __t(:bump!, body, uri)
 
 
   @doc false
   def __c(urn, meta) do
     if ctx = Process.delete(:tirexs_resources_chain) do
       args = case urn do
-        urn when is_binary(urn) -> [ urn, ctx[:uri] ]
-        [ urn, body ]           -> [ urn, ctx[:uri], body ]
+        urn when is_binary(urn) -> [ urn, ctx[:uri], ctx[:body] ]
       end
       Kernel.apply(Tirexs.HTTP, meta[ctx[:label]], args)
     else
@@ -102,8 +105,8 @@ defmodule Tirexs.Resources do
   end
 
   @doc false
-  defp __t(label, uri \\ Tirexs.ENV.get_uri_env()) do
-    Process.put(:tirexs_resources_chain, [label: label, uri: uri])
+  defp __t(label, body \\ [], %URI{} = uri \\ Tirexs.ENV.get_uri_env()) do
+    Process.put(:tirexs_resources_chain, [label: label, body: body, uri: uri])
     Tirexs.Resources.APIs
   end
 end

--- a/lib/tirexs/resources.ex
+++ b/lib/tirexs/resources.ex
@@ -79,6 +79,11 @@ defmodule Tirexs.Resources do
       iex> bump._refresh(["bear_test", "duck_test"], { [force: false] })
       { :ok, 200, ... }
 
+  It is also available for bumping some resources with request body:
+
+      iex> search = [query: [ term: [ user: "zatvobor" ] ] ]
+      iex> bump(search)._count("bear_test", "my_type")
+
   Play with resources you have and see what kind of HTTP verb is used.
 
   """

--- a/lib/tirexs/resources.ex
+++ b/lib/tirexs/resources.ex
@@ -93,10 +93,11 @@ defmodule Tirexs.Resources do
 
 
   @doc false
-  def __c(urn, meta) do
+  def __c(urn, meta) when is_binary(urn) do
     if ctx = Process.delete(:tirexs_resources_chain) do
-      args = case urn do
-        urn when is_binary(urn) -> [ urn, ctx[:uri], ctx[:body] ]
+      args = case { urn, ctx[:body] } do
+        { urn, [] }   -> [ urn, ctx[:uri] ]
+        { urn, body } -> [ urn, ctx[:uri], body ]
       end
       Kernel.apply(Tirexs.HTTP, meta[ctx[:label]], args)
     else

--- a/lib/tirexs/resources/apis.ex
+++ b/lib/tirexs/resources/apis.ex
@@ -41,7 +41,7 @@ defmodule Tirexs.Resources.APIs do
 
 
   @doc false
-  defdelegate [ _explain(a,b), _explain(a,b,c,d) ], to: Search
+  defdelegate [ _explain(a), _explain(a,b), _explain(a,b,c), _explain(a,b,c,d) ], to: Search
 
 
   alias Tirexs.Resources.Indices

--- a/lib/tirexs/resources/apis.ex
+++ b/lib/tirexs/resources/apis.ex
@@ -42,6 +42,7 @@ defmodule Tirexs.Resources.APIs do
 
   @doc false
   defdelegate [ _explain(a), _explain(a,b), _explain(a,b,c), _explain(a,b,c,d) ], to: Search
+  defdelegate [ _search_shards(a), _search_shards(a,b), _search_shards(a,b,c) ], to: Search
 
 
   alias Tirexs.Resources.Indices

--- a/lib/tirexs/resources/apis.ex
+++ b/lib/tirexs/resources/apis.ex
@@ -44,6 +44,7 @@ defmodule Tirexs.Resources.APIs do
   defdelegate [ _explain(a), _explain(a,b), _explain(a,b,c), _explain(a,b,c,d) ], to: Search
   defdelegate [ _search_shards(a), _search_shards(a,b), _search_shards(a,b,c) ], to: Search
   defdelegate [ _field_stats(), _field_stats(a), _field_stats(a,b) ], to: Search
+  defdelegate [ _validate_query(), _validate_query(a), _validate_query(a,b), _validate_query(a,b,c) ], to: Search
 
 
   alias Tirexs.Resources.Indices

--- a/lib/tirexs/resources/apis.ex
+++ b/lib/tirexs/resources/apis.ex
@@ -45,6 +45,7 @@ defmodule Tirexs.Resources.APIs do
   defdelegate [ _search_shards(a), _search_shards(a,b), _search_shards(a,b,c) ], to: Search
   defdelegate [ _field_stats(), _field_stats(a), _field_stats(a,b) ], to: Search
   defdelegate [ _validate_query(), _validate_query(a), _validate_query(a,b), _validate_query(a,b,c) ], to: Search
+  defdelegate [ _count(), _count(a), _count(a,b), _count(a,b,c) ], to: Search
 
 
   alias Tirexs.Resources.Indices

--- a/lib/tirexs/resources/apis.ex
+++ b/lib/tirexs/resources/apis.ex
@@ -47,6 +47,7 @@ defmodule Tirexs.Resources.APIs do
   defdelegate [ _validate_query(), _validate_query(a), _validate_query(a,b), _validate_query(a,b,c) ], to: Search
   defdelegate [ _count(), _count(a), _count(a,b), _count(a,b,c) ], to: Search
   defdelegate [ _search_exists(), _search_exists(a), _search_exists(a,b), _search_exists(a,b,c) ], to: Search
+  defdelegate [ _search(), _search(a), _search(a,b), _search(a,b,c) ], to: Search
 
 
   alias Tirexs.Resources.Indices

--- a/lib/tirexs/resources/apis.ex
+++ b/lib/tirexs/resources/apis.ex
@@ -46,6 +46,7 @@ defmodule Tirexs.Resources.APIs do
   defdelegate [ _field_stats(), _field_stats(a), _field_stats(a,b) ], to: Search
   defdelegate [ _validate_query(), _validate_query(a), _validate_query(a,b), _validate_query(a,b,c) ], to: Search
   defdelegate [ _count(), _count(a), _count(a,b), _count(a,b,c) ], to: Search
+  defdelegate [ _search_exists(), _search_exists(a), _search_exists(a,b), _search_exists(a,b,c) ], to: Search
 
 
   alias Tirexs.Resources.Indices

--- a/lib/tirexs/resources/apis.ex
+++ b/lib/tirexs/resources/apis.ex
@@ -43,6 +43,7 @@ defmodule Tirexs.Resources.APIs do
   @doc false
   defdelegate [ _explain(a), _explain(a,b), _explain(a,b,c), _explain(a,b,c,d) ], to: Search
   defdelegate [ _search_shards(a), _search_shards(a,b), _search_shards(a,b,c) ], to: Search
+  defdelegate [ _field_stats(), _field_stats(a), _field_stats(a,b) ], to: Search
 
 
   alias Tirexs.Resources.Indices

--- a/lib/tirexs/resources/apis.ex
+++ b/lib/tirexs/resources/apis.ex
@@ -37,8 +37,14 @@ defmodule Tirexs.Resources.APIs do
 
   """
 
-  alias Tirexs.Resources.Indices
+  alias Tirexs.Resources.Search
 
+
+  @doc false
+  defdelegate [ _explain(a,b), _explain(a,b,c,d) ], to: Search
+
+
+  alias Tirexs.Resources.Indices
 
   ## Mapping Management
 

--- a/lib/tirexs/resources/search.ex
+++ b/lib/tirexs/resources/search.ex
@@ -10,4 +10,10 @@ defmodule Tirexs.Resources.Search do
   def _explain(a, b, c), do: __c(urn([a, b, c, @r[:action]]), @r)
   def _explain(a, b), do: __c(urn([a, @r[:action], b]), @r)
   def _explain(a), do: __c(urn([a, @r[:action]]), @r)
+
+  @r [action: "/_search_shards", bump: :get, bump!: :get!]
+  def _search_shards(a, b, c), do: __c(urn([a, b, @r[:action], c]), @r)
+  def _search_shards(a, {b}), do: __c(urn([a, @r[:action], {b}]), @r)
+  def _search_shards(a, b), do: __c(urn([a, b, @r[:action]]), @r)
+  def _search_shards(a), do: __c(urn([a, @r[:action]]), @r)
 end

--- a/lib/tirexs/resources/search.ex
+++ b/lib/tirexs/resources/search.ex
@@ -42,4 +42,13 @@ defmodule Tirexs.Resources.Search do
   def _count({a}), do: __c(urn([@r[:action], {a}]), @r)
   def _count(a), do: __c(urn([a, @r[:action]]), @r)
   def _count(), do: __c(urn([@r[:action]]), @r)
+
+  @doc false
+  @r [action: "/_search/exists", bump: :post, bump!: :post!]
+  def _search_exists(a, b, c), do: __c(urn([a, b, @r[:action], c]), @r)
+  def _search_exists(a, {b}), do: __c(urn([a, @r[:action], {b}]), @r)
+  def _search_exists(a, b), do: __c(urn([a, b, @r[:action]]), @r)
+  def _search_exists({a}), do: __c(urn([@r[:action], {a}]), @r)
+  def _search_exists(a), do: __c(urn([a, @r[:action]]), @r)
+  def _search_exists(), do: __c(urn([@r[:action]]), @r)
 end

--- a/lib/tirexs/resources/search.ex
+++ b/lib/tirexs/resources/search.ex
@@ -11,9 +11,17 @@ defmodule Tirexs.Resources.Search do
   def _explain(a, b), do: __c(urn([a, @r[:action], b]), @r)
   def _explain(a), do: __c(urn([a, @r[:action]]), @r)
 
+  @doc false
   @r [action: "/_search_shards", bump: :get, bump!: :get!]
   def _search_shards(a, b, c), do: __c(urn([a, b, @r[:action], c]), @r)
   def _search_shards(a, {b}), do: __c(urn([a, @r[:action], {b}]), @r)
   def _search_shards(a, b), do: __c(urn([a, b, @r[:action]]), @r)
   def _search_shards(a), do: __c(urn([a, @r[:action]]), @r)
+
+  @doc false
+  @r [action: "/_field_stats", bump: :post, bump!: :post!]
+  def _field_stats(a, b), do: __c(urn([a, @r[:action], b]), @r)
+  def _field_stats({a}), do: __c(urn([@r[:action], {a}]), @r)
+  def _field_stats(a), do: __c(urn([a, @r[:action]]), @r)
+  def _field_stats(), do: __c(urn([@r[:action]]), @r)
 end

--- a/lib/tirexs/resources/search.ex
+++ b/lib/tirexs/resources/search.ex
@@ -24,4 +24,13 @@ defmodule Tirexs.Resources.Search do
   def _field_stats({a}), do: __c(urn([@r[:action], {a}]), @r)
   def _field_stats(a), do: __c(urn([a, @r[:action]]), @r)
   def _field_stats(), do: __c(urn([@r[:action]]), @r)
+
+  @doc false
+  @r [action: "/_validate/query", bump: :post, bump!: :post!]
+  def _validate_query(a, b, c), do: __c(urn([a, b, @r[:action], c]), @r)
+  def _validate_query(a, {b}), do: __c(urn([a, @r[:action], {b}]), @r)
+  def _validate_query(a, b), do: __c(urn([a, b, @r[:action]]), @r)
+  def _validate_query({a}), do: __c(urn([@r[:action], {a}]), @r)
+  def _validate_query(a), do: __c(urn([a, @r[:action]]), @r)
+  def _validate_query(), do: __c(urn([@r[:action]]), @r)
 end

--- a/lib/tirexs/resources/search.ex
+++ b/lib/tirexs/resources/search.ex
@@ -7,5 +7,7 @@ defmodule Tirexs.Resources.Search do
   @doc false
   @r [action: "/_explain", bump: :post, bump!: :post!]
   def _explain(a, b, c, d), do: __c(urn([a, b, c, @r[:action], d]), @r)
+  def _explain(a, b, c), do: __c(urn([a, b, c, @r[:action]]), @r)
   def _explain(a, b), do: __c(urn([a, @r[:action], b]), @r)
+  def _explain(a), do: __c(urn([a, @r[:action]]), @r)
 end

--- a/lib/tirexs/resources/search.ex
+++ b/lib/tirexs/resources/search.ex
@@ -1,0 +1,11 @@
+defmodule Tirexs.Resources.Search do
+  @moduledoc false
+
+  import Tirexs.Resources, only: [urn: 1, __c: 2]
+
+
+  @doc false
+  @r [action: "/_explain", bump: :post, bump!: :post!]
+  def _explain(a, b, c, d), do: __c(urn([a, b, c, @r[:action], d]), @r)
+  def _explain(a, b), do: __c(urn([a, @r[:action], b]), @r)
+end

--- a/lib/tirexs/resources/search.ex
+++ b/lib/tirexs/resources/search.ex
@@ -51,4 +51,13 @@ defmodule Tirexs.Resources.Search do
   def _search_exists({a}), do: __c(urn([@r[:action], {a}]), @r)
   def _search_exists(a), do: __c(urn([a, @r[:action]]), @r)
   def _search_exists(), do: __c(urn([@r[:action]]), @r)
+
+  @doc false
+  @r [action: "/_search", bump: :post, bump!: :post!]
+  def _search(a, b, c), do: __c(urn([a, b, @r[:action], c]), @r)
+  def _search(a, {b}), do: __c(urn([a, @r[:action], {b}]), @r)
+  def _search(a, b), do: __c(urn([a, b, @r[:action]]), @r)
+  def _search({a}), do: __c(urn([@r[:action], {a}]), @r)
+  def _search(a), do: __c(urn([a, @r[:action]]), @r)
+  def _search(), do: __c(urn([@r[:action]]), @r)
 end

--- a/lib/tirexs/resources/search.ex
+++ b/lib/tirexs/resources/search.ex
@@ -33,4 +33,13 @@ defmodule Tirexs.Resources.Search do
   def _validate_query({a}), do: __c(urn([@r[:action], {a}]), @r)
   def _validate_query(a), do: __c(urn([a, @r[:action]]), @r)
   def _validate_query(), do: __c(urn([@r[:action]]), @r)
+
+  @doc false
+  @r [action: "/_count", bump: :post, bump!: :post!]
+  def _count(a, b, c), do: __c(urn([a, b, @r[:action], c]), @r)
+  def _count(a, {b}), do: __c(urn([a, @r[:action], {b}]), @r)
+  def _count(a, b), do: __c(urn([a, b, @r[:action]]), @r)
+  def _count({a}), do: __c(urn([@r[:action], {a}]), @r)
+  def _count(a), do: __c(urn([a, @r[:action]]), @r)
+  def _count(), do: __c(urn([@r[:action]]), @r)
 end

--- a/test/acceptances/resources/search_test.exs
+++ b/test/acceptances/resources/search_test.exs
@@ -76,4 +76,11 @@ defmodule Acceptances.Resources.SearchTest do
     { :ok, 200, r } = Resources.bump(search)._search_exists("bear_test", "my_type")
     assert r[:exists]
   end
+
+  test "_search/2" do
+    { :ok, 201, _ } = HTTP.put("/bear_test/my_type/2?refresh=true", [user: "zatvobor"])
+    search          = [query: [ term: [ user: "zatvobor" ] ]]
+    { :ok, 200, r } = Resources.bump(search)._search("bear_test", "my_type")
+    assert r[:hits][:total] == 1
+  end
 end

--- a/test/acceptances/resources/search_test.exs
+++ b/test/acceptances/resources/search_test.exs
@@ -69,4 +69,11 @@ defmodule Acceptances.Resources.SearchTest do
     { :ok, 200, r } = Resources.bump(search)._count("bear_test", "my_type")
     assert r[:count] == 1
   end
+
+  test "_search_exists/2" do
+    { :ok, 201, _ } = HTTP.put("/bear_test/my_type/2?refresh=true", [user: "zatvobor"])
+    search          = [query: [ term: [ user: "zatvobor" ] ]]
+    { :ok, 200, r } = Resources.bump(search)._search_exists("bear_test", "my_type")
+    assert r[:exists]
+  end
 end

--- a/test/acceptances/resources/search_test.exs
+++ b/test/acceptances/resources/search_test.exs
@@ -49,4 +49,17 @@ defmodule Acceptances.Resources.SearchTest do
     { :ok, 200, _ } = HTTP.put("/bear_test")
     { :ok, 200, _ } = Resources.bump._field_stats("bear_test", { [fields: "some"] })
   end
+
+  test "_validate_query/2" do
+    { :ok, 201, _ } = HTTP.put("/bear_test/my_type/1?refresh=true", [user: "kimchy"])
+    { :ok, 200, r } = Resources.bump._validate_query("bear_test", { [q: "user1:z*"] })
+    assert r[:valid]
+  end
+
+  test "_validate_query/1" do
+    { :ok, 201, _ } = HTTP.put("/bear_test/my_type/2?refresh=true", [user: "zatvobor"])
+    search          = [query: [ term: [ user: "zatvobor" ] ]]
+    { :ok, 200, r } = Resources.bump(search)._validate_query("bear_test")
+    assert r[:valid]
+  end
 end

--- a/test/acceptances/resources/search_test.exs
+++ b/test/acceptances/resources/search_test.exs
@@ -62,4 +62,11 @@ defmodule Acceptances.Resources.SearchTest do
     { :ok, 200, r } = Resources.bump(search)._validate_query("bear_test")
     assert r[:valid]
   end
+
+  test "_count/2" do
+    { :ok, 201, _ } = HTTP.put("/bear_test/my_type/2?refresh=true", [user: "zatvobor"])
+    search          = [query: [ term: [ user: "zatvobor" ] ]]
+    { :ok, 200, r } = Resources.bump(search)._count("bear_test", "my_type")
+    assert r[:count] == 1
+  end
 end

--- a/test/acceptances/resources/search_test.exs
+++ b/test/acceptances/resources/search_test.exs
@@ -15,9 +15,23 @@ defmodule Acceptances.Resources.SearchTest do
     assert r[:matched]
   end
 
+  test "_explain/3" do
+    { :ok, 201, _ } = HTTP.put("/bear_test/my_type/1?refresh=true", [user: "kimchy"])
+    search          = [query: [ term: [ user: "kimchy" ] ]]
+    { :ok, 200, r } = Resources.bump(search)._explain("bear_test", "my_type", "1")
+    assert r[:matched]
+  end
+
   test "_explain/2" do
     { :ok, 201, _ } = HTTP.put("/bear_test/my_type/2?refresh=true", [user: "zatvobor"])
     { :ok, 200, r } = Resources.bump._explain("bear_test/my_type/2", { [q: "user:z*"] })
+    assert r[:matched]
+  end
+
+  test "_explain/1" do
+    { :ok, 201, _ } = HTTP.put("/bear_test/my_type/2?refresh=true", [user: "zatvobor"])
+    search          = [query: [ term: [ user: "zatvobor" ] ]]
+    { :ok, 200, r } = Resources.bump(search)._explain("bear_test/my_type/2")
     assert r[:matched]
   end
 end

--- a/test/acceptances/resources/search_test.exs
+++ b/test/acceptances/resources/search_test.exs
@@ -39,4 +39,14 @@ defmodule Acceptances.Resources.SearchTest do
     { :ok, 200, _ } = HTTP.put("/bear_test")
     { :ok, 200, _ } = Resources.bump._search_shards("bear_test", { [local: true] })
   end
+
+  test "_field_stats/0" do
+    { :ok, 200, _ } = HTTP.put("/bear_test")
+    { :ok, 200, _ } = Resources.bump([fields: ["rating"]])._field_stats()
+  end
+
+  test "_field_stats/2" do
+    { :ok, 200, _ } = HTTP.put("/bear_test")
+    { :ok, 200, _ } = Resources.bump._field_stats("bear_test", { [fields: "some"] })
+  end
 end

--- a/test/acceptances/resources/search_test.exs
+++ b/test/acceptances/resources/search_test.exs
@@ -34,4 +34,9 @@ defmodule Acceptances.Resources.SearchTest do
     { :ok, 200, r } = Resources.bump(search)._explain("bear_test/my_type/2")
     assert r[:matched]
   end
+
+  test "_search_shards/2" do
+    { :ok, 200, _ } = HTTP.put("/bear_test")
+    { :ok, 200, _ } = Resources.bump._search_shards("bear_test", { [local: true] })
+  end
 end

--- a/test/acceptances/resources/search_test.exs
+++ b/test/acceptances/resources/search_test.exs
@@ -1,0 +1,23 @@
+defmodule Acceptances.Resources.SearchTest do
+  use ExUnit.Case
+
+  alias Tirexs.{HTTP, Resources}
+
+
+  setup do
+    HTTP.delete("bear_test") && :ok
+  end
+
+
+  test "_explain/4" do
+    { :ok, 201, _ } = HTTP.put("/bear_test/my_type/1?refresh=true", [user: "kimchy"])
+    { :ok, 200, r } = Resources.bump._explain("bear_test", "my_type", "1", { [q: "user:k*"] })
+    assert r[:matched]
+  end
+
+  test "_explain/2" do
+    { :ok, 201, _ } = HTTP.put("/bear_test/my_type/2?refresh=true", [user: "zatvobor"])
+    { :ok, 200, r } = Resources.bump._explain("bear_test/my_type/2", { [q: "user:z*"] })
+    assert r[:matched]
+  end
+end

--- a/test/tirexs/http_test.exs
+++ b/test/tirexs/http_test.exs
@@ -138,24 +138,24 @@ defmodule Tirexs.HTTPTest do
     assert actual == "http://127.0.0.1:92/articles/document/1?_source=false"
   end
 
-  test ~S(decode/1 {"hello":"world"}) do
-    actual = decode("{\"hello\":\"world\"}")
+  test ~S'decode/1 {"hello":"world"}' do
+    actual = decode(~S'{"hello":"world"}')
     assert actual == %{hello: "world"}
   end
 
-  test ~S(decode/1 {"hello":"world"} as list) do
-    actual = decode("{\"hello\":\"world\"}")
+  test ~S'decode/1 {"hello":"world"} as list' do
+    actual = decode(~S'{"hello":"world"}')
     assert Map.to_list(actual) == [hello: "world"]
   end
 
-  test ~S(decode/1 "hello" string) do
+  test ~S'decode/1 "hello" string' do
     actual = decode("\"hello\"")
     assert actual == "hello"
   end
 
-  test ~S(encode/1 %{hello: "world"} as map) do
+  test ~S'encode/1 %{hello: "world"} as map' do
     actual = encode(%{hello: "world"})
-    assert actual == "{\"hello\":\"world\"}"
+    assert actual == ~S'{"hello":"world"}'
   end
 
   test "encode/1 %{hello: 'world'} as map" do
@@ -163,9 +163,14 @@ defmodule Tirexs.HTTPTest do
     assert actual == "{\"hello\":[119,111,114,108,100]}"
   end
 
-  test ~S(encode/1 [hello: "world"] as list) do
+  test ~S'encode/1 [hello: "world"] as list' do
     actual = encode([hello: "world"])
-    assert actual == "{\"hello\":\"world\"}"
+    assert actual == ~S'{"hello":"world"}'
+  end
+
+  test ~S'encode/1 [query: [ term: [ message: "search" ] ]] as list' do
+    actual = encode([query: [ term: [ message: "search" ] ]])
+    assert actual == ~S'{"query":{"term":{"message":"search"}}}'
   end
 
   test "encode/1 []" do

--- a/test/tirexs/resources/search_test.exs
+++ b/test/tirexs/resources/search_test.exs
@@ -13,4 +13,24 @@ defmodule Tirexs.Resources.SearchTest do
     actual = Search._explain("twitter", "tweet", "1", { [q: "message:search"] })
     assert actual == "twitter/tweet/1/_explain?q=message%3Asearch"
   end
+
+  test ~S| functions like a '_search_shards("twitter")' | do
+    actual = Search._search_shards("twitter")
+    assert actual == "twitter/_search_shards"
+  end
+
+  test ~S| functions like a '_search_shards("twitter", { [local: true] })' | do
+    actual = Search._search_shards("twitter", { [local: true] })
+    assert actual == "twitter/_search_shards?local=true"
+  end
+
+  test ~S| functions like a '_search_shards("twitter", "tweet", { [local: true] })' | do
+    actual = Search._search_shards("twitter", "tweet", { [local: true] })
+    assert actual == "twitter/tweet/_search_shards?local=true"
+  end
+
+  test ~S| functions like a '_search_shards("twitter", "tweet")' | do
+    actual = Search._search_shards("twitter", "tweet")
+    assert actual == "twitter/tweet/_search_shards"
+  end
 end

--- a/test/tirexs/resources/search_test.exs
+++ b/test/tirexs/resources/search_test.exs
@@ -43,4 +43,24 @@ defmodule Tirexs.Resources.SearchTest do
     actual = Search._field_stats("bear_test", { [fields: "rating"] })
     assert actual == "bear_test/_field_stats?fields=rating"
   end
+
+  test ~S| functions like a '_validate_query("twitter")' | do
+    actual = Search._validate_query("twitter")
+    assert actual == "twitter/_validate/query"
+  end
+
+  test ~S| functions like a '_validate_query("twitter", "tweet")' | do
+    actual = Search._validate_query("twitter", "tweet")
+    assert actual == "twitter/tweet/_validate/query"
+  end
+
+  test ~S| functions like a '_validate_query("twitter", { [explain: true] })' | do
+    actual = Search._validate_query("twitter", { [explain: true] })
+    assert actual == "twitter/_validate/query?explain=true"
+  end
+
+  test ~S| functions like a '_validate_query("twitter", "tweet", { [explain: true] })' | do
+    actual = Search._validate_query("twitter", "tweet", { [explain: true] })
+    assert actual == "twitter/tweet/_validate/query?explain=true"
+  end
 end

--- a/test/tirexs/resources/search_test.exs
+++ b/test/tirexs/resources/search_test.exs
@@ -63,4 +63,24 @@ defmodule Tirexs.Resources.SearchTest do
     actual = Search._validate_query("twitter", "tweet", { [explain: true] })
     assert actual == "twitter/tweet/_validate/query?explain=true"
   end
+
+  test ~S| functions like a '_count("twitter")' | do
+    actual = Search._count("twitter")
+    assert actual == "twitter/_count"
+  end
+
+  test ~S| functions like a '_count("twitter", "tweet")' | do
+    actual = Search._count("twitter", "tweet")
+    assert actual == "twitter/tweet/_count"
+  end
+
+  test ~S| functions like a '_count("twitter", { [lowercase_expanded_terms: true] })' | do
+    actual = Search._count("twitter", { [lowercase_expanded_terms: true] })
+    assert actual == "twitter/_count?lowercase_expanded_terms=true"
+  end
+
+  test ~S| functions like a '_validate_query("twitter", "tweet", { [lowercase_expanded_terms: true] })' | do
+    actual = Search._count("twitter", "tweet", { [lowercase_expanded_terms: true] })
+    assert actual == "twitter/tweet/_count?lowercase_expanded_terms=true"
+  end
 end

--- a/test/tirexs/resources/search_test.exs
+++ b/test/tirexs/resources/search_test.exs
@@ -33,4 +33,14 @@ defmodule Tirexs.Resources.SearchTest do
     actual = Search._search_shards("twitter", "tweet")
     assert actual == "twitter/tweet/_search_shards"
   end
+
+  test ~S| functions like a '_field_stats(["index1", "index2"])' | do
+    actual = Search._field_stats(["index1", "index2"])
+    assert actual == "index1,index2/_field_stats"
+  end
+
+  test ~S| functions like a '_field_stats("bear_test", { [fields: "rating"] })' | do
+    actual = Search._field_stats("bear_test", { [fields: "rating"] })
+    assert actual == "bear_test/_field_stats?fields=rating"
+  end
 end

--- a/test/tirexs/resources/search_test.exs
+++ b/test/tirexs/resources/search_test.exs
@@ -79,8 +79,28 @@ defmodule Tirexs.Resources.SearchTest do
     assert actual == "twitter/_count?lowercase_expanded_terms=true"
   end
 
-  test ~S| functions like a '_validate_query("twitter", "tweet", { [lowercase_expanded_terms: true] })' | do
+  test ~S| functions like a '_count("twitter", "tweet", { [lowercase_expanded_terms: true] })' | do
     actual = Search._count("twitter", "tweet", { [lowercase_expanded_terms: true] })
     assert actual == "twitter/tweet/_count?lowercase_expanded_terms=true"
+  end
+
+  test ~S| functions like a '_search_exists("twitter")' | do
+    actual = Search._search_exists("twitter")
+    assert actual == "twitter/_search/exists"
+  end
+
+  test ~S| functions like a '_search_exists("twitter", "tweet")' | do
+    actual = Search._search_exists("twitter", "tweet")
+    assert actual == "twitter/tweet/_search/exists"
+  end
+
+  test ~S| functions like a '_search_exists("twitter/tweet", { [q: "user:kimchy"] })' | do
+    actual = Search._search_exists("twitter/tweet", { [q: "user:kimchy"] })
+    assert actual == "twitter/tweet/_search/exists?q=user%3Akimchy"
+  end
+
+  test ~S| functions like a '_search_exists("twitter", "tweet", { [q: "user:kimchy"] })' | do
+    actual = Search._search_exists("twitter", "tweet", { [q: "user:kimchy"] })
+    assert actual == "twitter/tweet/_search/exists?q=user%3Akimchy"
   end
 end

--- a/test/tirexs/resources/search_test.exs
+++ b/test/tirexs/resources/search_test.exs
@@ -103,4 +103,39 @@ defmodule Tirexs.Resources.SearchTest do
     actual = Search._search_exists("twitter", "tweet", { [q: "user:kimchy"] })
     assert actual == "twitter/tweet/_search/exists?q=user%3Akimchy"
   end
+
+  test ~S| functions like a '_search({ [q: "tag:wow"] })' | do
+    actual = Search._search({ [q: "tag:wow"] })
+    assert actual == "_search?q=tag%3Awow"
+  end
+
+  test ~S| functions like a '_search("twitter")' | do
+    actual = Search._search("twitter")
+    assert actual == "twitter/_search"
+  end
+
+  test ~S| functions like a '_search("twitter", "tweet")' | do
+    actual = Search._search("twitter", "tweet")
+    assert actual == "twitter/tweet/_search"
+  end
+
+  test ~S| functions like a '_search("twitter", ["tweet","user"])' | do
+    actual = Search._search("twitter", ["tweet","user"])
+    assert actual == "twitter/tweet,user/_search"
+  end
+
+  test ~S| functions like a '_search("twitter", ["tweet","user"], { [q: "user:kimchy"] })' | do
+    actual = Search._search("twitter", ["tweet","user"], { [q: "user:kimchy"] })
+    assert actual == "twitter/tweet,user/_search?q=user%3Akimchy"
+  end
+
+  test ~S| functions like a '_search("twitter/tweet", { [q: "user:kimchy"] })' | do
+    actual = Search._search("twitter/tweet", { [q: "user:kimchy"] })
+    assert actual == "twitter/tweet/_search?q=user%3Akimchy"
+  end
+
+  test ~S| functions like a '_search("twitter", "tweet", { [q: "user:kimchy"] })' | do
+    actual = Search._search("twitter", "tweet", { [q: "user:kimchy"] })
+    assert actual == "twitter/tweet/_search?q=user%3Akimchy"
+  end
 end

--- a/test/tirexs/resources/search_test.exs
+++ b/test/tirexs/resources/search_test.exs
@@ -1,0 +1,16 @@
+defmodule Tirexs.Resources.SearchTest do
+  use ExUnit.Case
+
+  alias Tirexs.Resources.Search
+
+
+  test ~S| functions like a '_explain("twitter/tweet/1", { [q: "message:search"] })' | do
+    actual = Search._explain("twitter/tweet/1", { [q: "message:search"] })
+    assert actual == "twitter/tweet/1/_explain?q=message%3Asearch"
+  end
+
+  test ~S| functions like a '_explain("twitter", "tweet", "1", { [q: "message:search"] })' | do
+    actual = Search._explain("twitter", "tweet", "1", { [q: "message:search"] })
+    assert actual == "twitter/tweet/1/_explain?q=message%3Asearch"
+  end
+end

--- a/test/tirexs/resources_test.exs
+++ b/test/tirexs/resources_test.exs
@@ -1,7 +1,6 @@
 defmodule Tirexs.ResourcesTest do
   use ExUnit.Case
 
-  # alias Tirexs.{HTTP, Resources}
   import Tirexs.Resources
 
 


### PR DESCRIPTION
According to the main ES specs, https://github.com/elastic/elasticsearch/tree/master/rest-api-spec/src/main/resources/rest-api-spec/api

`Tirexs.Resources.Search` implements Search API (https://www.elastic.co/guide/en/elasticsearch/reference/2.2/search.html):

- [x] Explain API (query string as a parameter, or using a request body)
- [x] URI, Mutli-Index, Mutli-Type Search (query string as a parameter, or using a request body), Profile API
- [x] Search Shards API
- [x] Count API (query string as a parameter, or using a request body)
- [x] Mutli-Index, Mutli-Type Search Exists API (query string as a parameter, or using a request body)
- [x] Validate API (query string as a parameter, or using a request body)
- [x] Field Stats API (query string as a parameter, or using a request body)