### PR TITLE
Fix elixir 1.3 warnings in macros

### DIFF
--- a/lib/tirexs/index/logic.ex
+++ b/lib/tirexs/index/logic.ex
@@ -4,48 +4,40 @@ defmodule Tirexs.Index.Logic do
 
   @doc false
   def put_setting(index, type) do
-    settings = index[:settings]
-    settings = Keyword.put(settings, type, [])
-    Keyword.put(index, :settings, settings)
+    update_in(index[:settings][type], fn
+      nil -> []
+      settings -> settings
+    end)
   end
 
   @doc false
   def put_index_setting(index, main_type, type) do
-    index_settings = index[:settings][main_type]
-    index_settings = Keyword.put(index_settings, type, [])
+    update_in(index[:settings][main_type][type], fn
+      nil -> []
+      settings -> settings
+    end)
+  end
 
-    pass_settings(index, main_type, index_settings)
+  @doc false
+  def put_index_setting_nested_type(index, main_type, type, nested_type) do
+    update_in(index[:settings][main_type][type][nested_type], fn
+      nil -> []
+      settings -> settings
+    end)
   end
 
   @doc false
   def add_index_setting(index, value) do
-    index_settings = index[:settings][:index]
-
-    pass_settings(index, :index, index_settings ++ value)
+    update_in(index[:settings][:index], &(&1 ++ value))
   end
 
   @doc false
   def add_index_setting(index, main_type, type, value) do
-    main_index_settings = index[:settings][main_type]
-    type_settings       = index[:settings][main_type][type]
-    main_index_settings = Keyword.put(main_index_settings, type, type_settings ++ value)
-
-    pass_settings(index, main_type, main_index_settings)
+    update_in(index[:settings][main_type][type], &(&1 ++ value))
   end
 
   @doc false
   def add_index_setting_nested_type(index, main_type, type, nested_type, value) do
-    main_index_settings = index[:settings][main_type]
-    type_settings       = index[:settings][main_type][type]
-    type_with_nested_type_settings = type_settings[nested_type]
-    type_settings       = Keyword.put(type_settings, nested_type, type_with_nested_type_settings ++ value)
-    main_index_settings = Keyword.put(main_index_settings, type, type_settings)
-
-    pass_settings(index, main_type, main_index_settings)
-  end
-
-
-  defp pass_settings(index, type, settings) do
-    Keyword.put(index, :settings, Keyword.put(index[:settings], type, settings))
+    update_in(index[:settings][main_type][type][nested_type], &(&1 ++ value))
   end
 end

--- a/lib/tirexs/index/settings.ex
+++ b/lib/tirexs/index/settings.ex
@@ -17,11 +17,7 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro filters([do: block]) do
     quote do
-      var!(index) = if var!(index)[:settings][:analysis] == nil do
-        put_setting(var!(index), :analysis)
-      else
-        var!(index)
-      end
+      var!(index) = put_setting(var!(index), :analysis)
       unquote(block)
     end
   end
@@ -29,11 +25,7 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro analysis([do: block]) do
     quote do
-      var!(index) = if var!(index)[:settings][:analysis] == nil do
-        put_setting(var!(index), :analysis)
-      else
-        var!(index)
-      end
+      var!(index) = put_setting(var!(index), :analysis)
       unquote(block)
     end
   end
@@ -49,11 +41,7 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro analyzer(name, value) do
     quote do
-      var!(index) = if var!(index)[:settings][:analysis][:analyzer] == nil do
-        put_index_setting(var!(index), :analysis, :analyzer)
-      else
-        var!(index)
-      end
+      var!(index) = put_index_setting(var!(index), :analysis, :analyzer)
       [name, value] = [unquote(name), unquote(value)]
       var!(index) = add_index_setting(var!(index), :analysis, :analyzer, Keyword.put([], to_atom(name), value))
     end
@@ -62,11 +50,7 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro blocks(value) do
     quote do
-      var!(index) = if var!(index)[:settings][:index][:blocks] == nil do
-        put_index_setting(var!(index), :index, :blocks)
-      else
-        var!(index)
-      end
+      var!(index) = put_index_setting(var!(index), :index, :blocks)
       value = unquote(value)
       var!(index) = add_index_setting(var!(index), :index, :blocks, value)
     end
@@ -75,12 +59,8 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro cache(value) do
     quote do
-      var!(index) = if var!(index)[:settings][:index][:cache] == nil do
-        index = put_index_setting(var!(index), :index, :cache)
-        add_index_setting(index, :index, :cache, [filter: []])
-      else
-        var!(index)
-      end
+      var!(index) = put_index_setting(var!(index), :index, :cache)
+      var!(index) = put_index_setting_nested_type(var!(index), :index, :cache, :filter)
       value = unquote(value)
       var!(index) = add_index_setting_nested_type(var!(index), :index, :cache, :filter, value)
     end
@@ -89,11 +69,7 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro filter(name, value) do
     quote do
-      var!(index) = if var!(index)[:settings][:analysis][:filter] == nil do
-        put_index_setting(var!(index), :analysis, :filter)
-      else
-        var!(index)
-      end
+      var!(index) = put_index_setting(var!(index), :analysis, :filter)
       [name, value] = [unquote(name), unquote(value)]
       var!(index) = add_index_setting(var!(index), :analysis, :filter, Keyword.put([], to_atom(name), value))
     end
@@ -102,11 +78,7 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro tokenizer(name, value) do
     quote do
-      var!(index) = if var!(index)[:settings][:analysis][:tokenizer] == nil do
-        put_index_setting(var!(index), :analysis, :tokenizer)
-      else
-        var!(index)
-      end
+      var!(index) = put_index_setting(var!(index), :analysis, :tokenizer)
       [name, value] = [unquote(name), unquote(value)]
       var!(index) = add_index_setting(var!(index), :analysis, :tokenizer, Keyword.put([], to_atom(name), value))
     end
@@ -115,11 +87,7 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro translog(value) do
     quote do
-      var!(index) = if var!(index)[:settings][:index][:translog] == nil do
-        put_index_setting(var!(index), :index, :translog)
-      else
-        var!(index)
-      end
+      var!(index) = put_index_setting(var!(index), :index, :translog)
       value = unquote(value)
       var!(index) = add_index_setting(var!(index), :index, :translog, value)
     end

--- a/lib/tirexs/index/settings.ex
+++ b/lib/tirexs/index/settings.ex
@@ -17,8 +17,10 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro filters([do: block]) do
     quote do
-      if var!(index)[:settings][:analysis] == nil do
-        var!(index) = put_setting(var!(index), :analysis)
+      var!(index) = if var!(index)[:settings][:analysis] == nil do
+        put_setting(var!(index), :analysis)
+      else
+        var!(index)
       end
       unquote(block)
     end
@@ -27,8 +29,10 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro analysis([do: block]) do
     quote do
-      if var!(index)[:settings][:analysis] == nil do
-        var!(index) = put_setting(var!(index), :analysis)
+      var!(index) = if var!(index)[:settings][:analysis] == nil do
+        put_setting(var!(index), :analysis)
+      else
+        var!(index)
       end
       unquote(block)
     end
@@ -45,8 +49,10 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro analyzer(name, value) do
     quote do
-      if var!(index)[:settings][:analysis][:analyzer] == nil do
-        var!(index) = put_index_setting(var!(index), :analysis, :analyzer)
+      var!(index) = if var!(index)[:settings][:analysis][:analyzer] == nil do
+        put_index_setting(var!(index), :analysis, :analyzer)
+      else
+        var!(index)
       end
       [name, value] = [unquote(name), unquote(value)]
       var!(index) = add_index_setting(var!(index), :analysis, :analyzer, Keyword.put([], to_atom(name), value))
@@ -56,8 +62,10 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro blocks(value) do
     quote do
-      if var!(index)[:settings][:index][:blocks] == nil do
-        var!(index) = put_index_setting(var!(index), :index, :blocks)
+      var!(index) = if var!(index)[:settings][:index][:blocks] == nil do
+        put_index_setting(var!(index), :index, :blocks)
+      else
+        var!(index)
       end
       value = unquote(value)
       var!(index) = add_index_setting(var!(index), :index, :blocks, value)
@@ -67,9 +75,11 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro cache(value) do
     quote do
-      if var!(index)[:settings][:index][:cache] == nil do
-        var!(index) = put_index_setting(var!(index), :index, :cache)
-        var!(index) = add_index_setting(var!(index), :index, :cache, [filter: []])
+      var!(index) = if var!(index)[:settings][:index][:cache] == nil do
+        index = put_index_setting(var!(index), :index, :cache)
+        add_index_setting(index, :index, :cache, [filter: []])
+      else
+        var!(index)
       end
       value = unquote(value)
       var!(index) = add_index_setting_nested_type(var!(index), :index, :cache, :filter, value)
@@ -79,8 +89,10 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro filter(name, value) do
     quote do
-      if var!(index)[:settings][:analysis][:filter] == nil do
-        var!(index) = put_index_setting(var!(index), :analysis, :filter)
+      var!(index) = if var!(index)[:settings][:analysis][:filter] == nil do
+        put_index_setting(var!(index), :analysis, :filter)
+      else
+        var!(index)
       end
       [name, value] = [unquote(name), unquote(value)]
       var!(index) = add_index_setting(var!(index), :analysis, :filter, Keyword.put([], to_atom(name), value))
@@ -90,8 +102,10 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro tokenizer(name, value) do
     quote do
-      if var!(index)[:settings][:analysis][:tokenizer] == nil do
-        var!(index) = put_index_setting(var!(index), :analysis, :tokenizer)
+      var!(index) = if var!(index)[:settings][:analysis][:tokenizer] == nil do
+        put_index_setting(var!(index), :analysis, :tokenizer)
+      else
+        var!(index)
       end
       [name, value] = [unquote(name), unquote(value)]
       var!(index) = add_index_setting(var!(index), :analysis, :tokenizer, Keyword.put([], to_atom(name), value))
@@ -101,8 +115,10 @@ defmodule Tirexs.Index.Settings do
   @doc false
   defmacro translog(value) do
     quote do
-      if var!(index)[:settings][:index][:translog] == nil do
-        var!(index) = put_index_setting(var!(index), :index, :translog)
+      var!(index) = if var!(index)[:settings][:index][:translog] == nil do
+        put_index_setting(var!(index), :index, :translog)
+      else
+        var!(index)
       end
       value = unquote(value)
       var!(index) = add_index_setting(var!(index), :index, :translog, value)

--- a/test/tirexs/index/settings_test.exs
+++ b/test/tirexs/index/settings_test.exs
@@ -16,7 +16,7 @@ defmodule Tirexs.Index.SettingsTest do
       cache     []
     end
 
-    expected = [index: [cache: [filter: []], translog: [], blocks: []], analysis: []]
+    expected = [analysis: [], index: [cache: [filter: []], translog: [], blocks: []]]
     assert index[:settings] == expected
   end
 
@@ -37,7 +37,7 @@ defmodule Tirexs.Index.SettingsTest do
       blocks write: true
     end
 
-    expected = [index: [blocks: [write: true], translog: [disable_flush: false], cache: [filter: [max_size: -1]], number_of_replicas: 3], analysis: [tokenizer: ["dot-tokenizer": [type: "path_hierarchy", delimiter: "."]], filter: [substring: [type: "nGram", min_gram: 2, max_gram: 32]], analyzer: [msg_search_analyzer: [tokenizer: "keyword", filter: ["lowercase"]], msg_index_analyzer: [tokenizer: "keyword", filter: ["lowercase","substring"]]]]]
+    expected = [analysis: [tokenizer: ["dot-tokenizer": [type: "path_hierarchy", delimiter: "."]], filter: [substring: [type: "nGram", min_gram: 2, max_gram: 32]], analyzer: [msg_search_analyzer: [tokenizer: "keyword", filter: ["lowercase"]], msg_index_analyzer: [tokenizer: "keyword", filter: ["lowercase","substring"]]]], index: [blocks: [write: true], translog: [disable_flush: false], cache: [filter: [max_size: -1]], number_of_replicas: 3]]
     assert index[:settings] == expected
   end
 end


### PR DESCRIPTION
These macros cause warnings at compile time for projects using tirexs with
Elixir 1.3. There are plenty of other warnings while compiling tirexs itself,
but I think these are higher priority.