### PR TITLE
Add :error pattern match for Tirexs.HTTP

### DIFF
--- a/lib/tirexs/http.ex
+++ b/lib/tirexs/http.ex
@@ -309,6 +309,7 @@ defmodule Tirexs.HTTP do
   Returns `false` if `{ :error, _, _ } = response`, otherwise returns `true`.
 
   """
+  def ok?(:error), do: false
   def ok?({ :error, _, _ }), do: false
   def ok?({ :ok, _, _ }), do: true
 

--- a/test/acceptances/http_test.exs
+++ b/test/acceptances/http_test.exs
@@ -10,6 +10,9 @@ defmodule Acceptances.HTTPTest do
     delete("bear_test") && :ok
   end
 
+  test "tries to reach an invalid uri" do
+    assert :error == head("bear_test", %URI{host: "0.0.0.0", port: 9999})
+  end
 
   test "tries to get some head for resource" do
     { :error, 404, _ } = head("unknown", @uri_environment)

--- a/test/acceptances/resources_test.exs
+++ b/test/acceptances/resources_test.exs
@@ -8,6 +8,9 @@ defmodule Acceptances.ResourcesTest do
     HTTP.delete("bear_test") && :ok
   end
 
+  test "tries to reach an invalid url" do
+    assert false == Resources.exists?("bear_test", %URI{host: "0.0.0.0", port: 9999})
+  end
 
   test "exists?/1" do
     { :ok, 200, _ } = HTTP.put("bear_test")


### PR DESCRIPTION
This could happen when elasticsearch is down