### PR TITLE
Relax elixir version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Tirexs.Mixfile do
       version: "0.8.3",
       source_url: github,
       homepage_url: github,
-      elixir: "~> 1.2.0",
+      elixir: "~> 1.2",
       description: description,
       package: package,
       deps: deps,


### PR DESCRIPTION
The test suite passes with latest elixir 1.4.0-dev, no need to lock the
lib at 1.2.0.