### PR TITLE
feat(query): add support for match_phrase

### DIFF
--- a/lib/tirexs/query.ex
+++ b/lib/tirexs/query.ex
@@ -42,6 +42,12 @@ defmodule Tirexs.Query do
   end
 
   @doc false
+  def match_phrase(options) do
+    [field,value, _] = extract_options(options)
+    [match_phrase: Keyword.put([], to_atom(field), value)]
+  end
+
+  @doc false
   def function_score(options) do
     opts = extract_block(options[:do])
     [function_score: extract(opts)]

--- a/lib/tirexs/query/logic.ex
+++ b/lib/tirexs/query/logic.ex
@@ -15,6 +15,7 @@ defmodule Tirexs.Query.Logic do
         {:should, _, [params]}                -> Query.should(params[:do])
         {:must_not, _, [params]}              -> Query.must_not(params[:do])
         {:match, _, params}                   -> Query.match(params)
+        {:match_phrase, _, params}             -> Query.match_phrase(params)
         {:multi_match, _, params}             -> Query.multi_match(params)
         {:query_string, _, params}            -> Query.query_string(params)
         {:string, _, params}                  -> Query.query_string(params)

--- a/test/tirexs/query_test.exs
+++ b/test/tirexs/query_test.exs
@@ -28,6 +28,14 @@ defmodule Tirexs.QueryTest do
     assert query == expected
   end
 
+  test "query w/ match_phrase" do
+    query = query do
+      match_phrase "message", "this phrase"
+    end
+    expected = [query: [match_phrase: [message: "this phrase"]]]
+    assert query == expected
+  end
+
   test "query w/ multi_match" do
     query = query do
       multi_match "this is a test", ["subject", "message"]


### PR DESCRIPTION
Adds support for the elasticsearch [match_phrase](https://www.elastic.co/guide/en/elasticsearch/guide/current/phrase-matching.html) query