### PR TITLE
Add min_score attribute for function score

### DIFF
--- a/lib/tirexs/query.ex
+++ b/lib/tirexs/query.ex
@@ -92,6 +92,11 @@ defmodule Tirexs.Query do
   end
 
   @doc false
+  def min_score(param) do
+    [min_score: Enum.fetch!(param, 0)]
+  end
+
+  @doc false
   def boosting(options, boosting_opts \\ [])
 
   @doc false

--- a/lib/tirexs/query/logic.ex
+++ b/lib/tirexs/query/logic.ex
@@ -43,6 +43,7 @@ defmodule Tirexs.Query.Logic do
         {:boost_mode, _, param}               -> Query.boost_mode(param)
         {:max_boost, _, param}                -> Query.max_boost(param)
         {:factor, _, param}                   -> Query.factor(param)
+        {:min_score, _, param}                -> Query.min_score(param)
         {:flt, _, params}                     -> Query.flt(params)
         {:flt_field, _, params}               -> Query.flt_field(params)
         {:fuzzy, _, params}                   -> Query.fuzzy(params)

--- a/test/tirexs/query_test.exs
+++ b/test/tirexs/query_test.exs
@@ -476,10 +476,11 @@ defmodule Tirexs.QueryTest do
         end
         boost_mode "sum"
         max_boost 1.5
+        min_score 0.8
       end
     end
 
-    expected = [query: [function_score: [query: [match_all: []], field_value_factor: [field: "votes", modifier: "log1p", factor: 2.0], boost_mode: "sum", max_boost: 1.5]]]
+    expected = [query: [function_score: [query: [match_all: []], field_value_factor: [field: "votes", modifier: "log1p", factor: 2.0], boost_mode: "sum", max_boost: 1.5, min_score: 0.8]]]
     assert query == expected
   end
 end


### PR DESCRIPTION
Hello,

I've added a `min_score` function for the function score query. 

Official documentation : https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html