### PR TITLE
Added support for extra mapping settings

### DIFF
--- a/examples/mapping_with_settings.exs
+++ b/examples/mapping_with_settings.exs
@@ -2,7 +2,7 @@
 # Run this example from console manually:
 #
 #   $ mix run -r examples/mapping.exs
-#   # => curl -X PUT -d '{ "settings": { "analysis": { "filter": { "edge_ngram": { "type": "edgeNGram", "min_gram": 1, "max_gram": 15 } }, "analyzer": { "autocomplete_analyzer": { "filter": [ "lowercase", "asciifolding", "edge_ngram" ], "tokenizer": "whitespace" } } }, "index": [] }, "mappings": { "dsl": { "properties": { "country": { "type": "string" }, "city": { "type": "string" }, "suburb": { "type": "string" }, "road": { "type": "string" }, "postcode": { "type": "string", "index": "not_analyzed" }, "housenumber": { "type": "string", "index": "not_analyzed" }, "coordinates": { "type": "geo_point" }, "full_address": { "type": "string", "analyzer": "autocomplete_analyzer" } } } } }' http://127.0.0.1:9200/bear_test
+#   # => curl -X PUT -d '{ "settings": { "analysis": { "filter": { "edge_ngram": { "type": "edgeNGram", "min_gram": 1, "max_gram": 15 } }, "analyzer": { "autocomplete_analyzer": { "filter": [ "lowercase", "asciifolding", "edge_ngram" ], "tokenizer": "whitespace" } } }, "index": [] }, "mappings": { "dsl": { "dynamic": "false", "properties": { "country": { "type": "string" }, "city": { "type": "string" }, "suburb": { "type": "string" }, "road": { "type": "string" }, "postcode": { "type": "string", "index": "not_analyzed" }, "housenumber": { "type": "string", "index": "not_analyzed" }, "coordinates": { "type": "geo_point" }, "full_address": { "type": "string", "analyzer": "autocomplete_analyzer" } } } } }' http://127.0.0.1:9200/bear_test
 #
 # Run this example from Elixir environment (`iex -S mix`):
 #
@@ -24,7 +24,7 @@ Tirexs.DSL.define(fn() ->
     end
   end
 
-  mappings do
+  mappings dynamic: "false" do
     indexes "country", type: "string"
     indexes "city", type: "string"
     indexes "suburb", type: "string"

--- a/lib/tirexs/mapping.ex
+++ b/lib/tirexs/mapping.ex
@@ -19,7 +19,7 @@ defmodule Tirexs.Mapping do
         end
       end
 
-      mappings do
+      mappings dynamic: false do
         indexes "country", type: "string"
         indexes "city", type: "string"
         indexes "suburb", type: "string"
@@ -46,13 +46,22 @@ defmodule Tirexs.Mapping do
   end
 
   @doc false
+  defmacro mappings(params, [do: block]) do
+    mappings = Keyword.merge(params, [properties: extract(block)])
+    quote_mappings(mappings)
+  end
+
+  @doc false
   defmacro mappings([do: block]) do
     mappings =  [properties: extract(block)]
+    quote_mappings(mappings)
+  end
+
+  defp quote_mappings(mappings) do
     quote do
       var!(index) = var!(index) ++ [mapping: unquote(mappings)]
     end
   end
-
 
   alias Tirexs.{Resources, HTTP}
 

--- a/test/acceptances/mapping_test.exs
+++ b/test/acceptances/mapping_test.exs
@@ -50,7 +50,7 @@ defmodule Acceptances.MappingTest do
         filter "edge_ngram", [type: "edgeNGram", min_gram: 1, max_gram: 15]
       end
     end
-    mappings do
+    mappings dynamic: "false", _parent: [type: "parent"] do
       indexes "country", type: "string"
       indexes "city", type: "string"
       indexes "suburb", type: "string"
@@ -76,6 +76,6 @@ defmodule Acceptances.MappingTest do
 
     %{article: properties} = mappings
 
-    assert %{properties: %{city: %{type: "string"}, coordinates: %{type: "geo_point"}, country: %{type: "string"}, full_address: %{analyzer: "autocomplete_analyzer", type: "string"}, housenumber: %{index: "not_analyzed", type: "string"}, postcode: %{index: "not_analyzed", type: "string"}, road: %{type: "string"}, suburb: %{type: "string"}}} == properties
+    assert %{dynamic: "false", _parent: %{type: "parent"}, _routing: %{required: true}, properties: %{city: %{type: "string"}, coordinates: %{type: "geo_point"}, country: %{type: "string"}, full_address: %{analyzer: "autocomplete_analyzer", type: "string"}, housenumber: %{index: "not_analyzed", type: "string"}, postcode: %{index: "not_analyzed", type: "string"}, road: %{type: "string"}, suburb: %{type: "string"}}} == properties
   end
 end

--- a/test/tirexs/mapping_test.exs
+++ b/test/tirexs/mapping_test.exs
@@ -23,6 +23,23 @@ defmodule Tirexs.MappingsTest do
     assert index[:mapping] == expected
   end
 
+  test "mappings with extra configurations" do
+    index = [index: "bear_test"]
+    mappings dynamic: "false", _parent: [type: "parent"] do
+      indexes "id", [
+        type: "multi_field",
+        fields: [
+          name_en: [ type: "string", analyzer: "analyzer_en", boost: 100],
+          exact: [type: "string", index: "not_analyzed"]
+        ]
+      ]
+      indexes "title", type: "string"
+    end
+
+    expected = [dynamic: "false", _parent: [type: "parent"], properties: [id: [type: "multi_field", fields: [name_en: [type: "string", analyzer: "analyzer_en", boost: 100], exact: [type: "string", index: "not_analyzed"]]], title: [type: "string"]]]
+    assert index[:mapping] == expected
+  end
+
   test "mappings w/ nested indexes" do
     index = [index: "bear_test"]
     mappings do


### PR DESCRIPTION
Hi there, I'm pretty new to Elixir, but that's a feature I really need in order to get my project running. 

Basically it allows you to add extra configuration to the index mapping like:
```
mappings dynamic: "false", _parent: [type: "parent_type"] do
```

Not sure if that's the best way to implement it, let me know if more work is needed.