### PR TITLE
remove underscore attrs when indexing/creating

### DIFF
--- a/lib/tirexs/bulk.ex
+++ b/lib/tirexs/bulk.ex
@@ -231,7 +231,7 @@ defmodule Tirexs.Bulk do
   defp __reduce(action) when action == :index or action == :create do
     fn(doc, acc) ->
       header = [{action, (take_id(doc) ++ take_header(doc))}]
-      meta   = drop_id(doc)
+      meta   = drop_id(doc) |> drop_undescored()
       acc ++ [header] ++ [meta]
     end
   end

--- a/test/tirexs/bulk_test.exs
+++ b/test/tirexs/bulk_test.exs
@@ -44,9 +44,9 @@ defmodule Tirexs.BulkTest do
   end
 
   @expected_string ~S'''
-  {"index":{"_index":"website","_type":"blog","_id":1}}
+  {"index":{"_index":"website","_type":"blog","_id":1,"_parent":123}}
   {"title":"My first blog post"}
-  {"index":{"_index":"website","_type":"blog","_id":2}}
+  {"index":{"_index":"website","_type":"blog","_id":2,"_parent":321}}
   {"title":"My second blog post"}
   {"update":{"_index":"website","_type":"blog","_id":1,"_retry_on_conflict":3}}
   {"doc":{"title":"[updated] My first blog post"},"fields":["_source"]}
@@ -57,8 +57,8 @@ defmodule Tirexs.BulkTest do
   test "payload_as_string/0 example w/ raw payload" do
     actual = payload_as_string do
       index   [ index: "website", type: "blog" ], [
-        [id: 1, title: "My first blog post"],
-        [id: 2, title: "My second blog post"]
+        [id: 1, title: "My first blog post", _parent: 123],
+        [id: 2, title: "My second blog post", _parent: 321]
       ]
       update  [ index: "website", type: "blog"], [
         [
@@ -77,8 +77,8 @@ defmodule Tirexs.BulkTest do
   test "payload_as_string/1 example w/ raw payload" do
     actual = payload_as_string([ index: "website", type: "blog" ]) do
       index [
-        [id: 1, title: "My first blog post"],
-        [id: 2, title: "My second blog post"]
+        [id: 1, title: "My first blog post", _parent: 123],
+        [id: 2, title: "My second blog post", _parent: 321]
       ]
       update [
         [


### PR DESCRIPTION
When using the Bulk API for actions like 'index' or 'create' we are not removing the set of reserved keywords (@underscored) attributes from the document, this PR just apply the 'drop_underscored()' function. Is there a reason for that? I'm not an expert on ES, so forgive me if I'm missing something.