### PR TITLE
add support for span_multi

### DIFF
--- a/lib/tirexs/query.ex
+++ b/lib/tirexs/query.ex
@@ -335,6 +335,11 @@ defmodule Tirexs.Query do
   end
 
   @doc false
+  def span_multi(options) do
+    [span_multi: extract(options)]
+  end
+
+  @doc false
   def terms(options) do
     [field, value, options] = extract_options(options)
     [terms: Keyword.put([], to_atom(field), value) ++ options]

--- a/lib/tirexs/query/logic.ex
+++ b/lib/tirexs/query/logic.ex
@@ -68,6 +68,7 @@ defmodule Tirexs.Query.Logic do
         {:clauses, _, [params]}               -> Query.clauses(params[:do])
         {:span_not, _, [params]}              -> Query.span_not(params[:do])
         {:span_not, _, options}               -> Query.span_not(options)
+        {:span_multi, _, [params]}            -> Query.span_multi(params[:do])
         {:include, _, [params]}               -> Query.include(params)
         {:exclude, _, [params]}               -> Query.exclude(params)
         {:span_or, _, [params]}               -> Query.span_or(params[:do])

--- a/test/tirexs/query_test.exs
+++ b/test/tirexs/query_test.exs
@@ -292,6 +292,17 @@ defmodule Tirexs.QueryTest do
     assert query == expected
   end
 
+  test "query w/ span_multi" do
+    query = query do
+      span_multi do
+        fuzzy "user", [value: "ki", boost: 1.0, min_similarity: 0.5, prefix_length: 0]
+      end
+    end
+
+    expected = [query: [span_multi: [fuzzy: [user: [value: "ki", boost: 1.0, min_similarity: 0.5, prefix_length: 0]]]]]
+    assert query == expected
+  end
+
   test "query w/ span_term" do
     query = query do
       span_term "field", [value: "value1", boost: 2.0]


### PR DESCRIPTION
Adds support for the elasticsearch [span_multi](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-multi-term-query.html) query