### PR TITLE
AWS Signing

### DIFF
--- a/lib/tirexs/http.ex
+++ b/lib/tirexs/http.ex
@@ -326,6 +326,7 @@ defmodule Tirexs.HTTP do
     url = if Tirexs.ENV.get_env(:aws_elasticsearch),
       do: sign_aws_url(method, url, headers, body),
       else: url
+
     resp = case method do
       :get    -> request(method, {url, headers}, [], [])
       :head   -> request(method, {url, headers}, [], [])
@@ -396,13 +397,16 @@ defmodule Tirexs.HTTP do
       to_string(url),
       Tirexs.ENV.get_env(:aws_region),
       "es",
-      headers_for_aws(headers),
+      headers_for_aws(method, headers),
       Timex.DateTime.now,
       payload
     ) |> to_charlist
   end
 
-  defp headers_for_aws(headers) do
+  # DELETE requests do not support headers
+  defp headers_for_aws(:delete, _), do: %{}
+
+  defp headers_for_aws(_method, headers) do
     headers |> Enum.map(fn {k,v} -> {to_string(k), to_string(v)} end) |> Enum.into(%{})
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Tirexs.Mixfile do
   defp deps do
     [
       {:exjsx, "~> 3.2.0"},
-      {:aws_auth, github: "radar/aws_auth"},
+      {:aws_auth, "~> 0.5.1"},
       {:ex_doc, "~> 0.12", only: :dev},
       {:earmark, "~> 1.0", only: :dev}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,12 @@ defmodule Tirexs.Mixfile do
   end
 
   defp deps do
-    [ {:exjsx, "~> 3.2.0"}, {:ex_doc, "~> 0.12", only: :dev}, {:earmark, "~> 1.0", only: :dev} ]
+    [
+      {:exjsx, "~> 3.2.0"},
+      {:aws_auth, "~> 0.5.1"},
+      {:ex_doc, "~> 0.12", only: :dev},
+      {:earmark, "~> 1.0", only: :dev}
+    ]
   end
 
   defp description do

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Tirexs.Mixfile do
   defp deps do
     [
       {:exjsx, "~> 3.2.0"},
-      {:aws_auth, "~> 0.5.1"},
+      {:aws_auth, github: "radar/aws_auth"},
       {:ex_doc, "~> 0.12", only: :dev},
       {:earmark, "~> 1.0", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,14 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+%{"certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
+  "combine": {:hex, :combine, "0.9.2", "cd3c8721f378ebe032487d8a4fa2ced3181a456a3c21b16464da8c46904bb552", [:mix], []},
+  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.0", "7136cc739ace295fc74c378f33699e5145bead4fdc1b4799822d0287489136fb", [:mix], [{:jsx, "~> 2.6.2", [hex: :jsx, optional: false]}]},
-  "jsx": {:hex, :jsx, "2.6.2", "213721e058da0587a4bce3cc8a00ff6684ced229c8f9223245c6ff2c88fbaa5a", [:mix, :rebar], []}}
+  "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
+  "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
+  "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
+  "jsx": {:hex, :jsx, "2.6.2", "213721e058da0587a4bce3cc8a00ff6684ced229c8f9223245c6ff2c88fbaa5a", [:mix, :rebar], []},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
+  "timex": {:hex, :timex, "2.2.1", "0d69012a7fd69f4cbdaa00cc5f2a5f30f1bed56072fb362ed4bddf60db343022", [:mix], [{:combine, "~> 0.7", [hex: :combine, optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, optional: false]}]},
+  "tzdata": {:hex, :tzdata, "0.5.9", "575be217b039057a47e133b72838cbe104fb5329b19906ea4e66857001c37edb", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, optional: false]}]}}


### PR DESCRIPTION
Hello! 

I've come across a usecase where I want to use this package with an AWS Elasticsearch instance, and I _also_ want to have requests signed because the documents are sensitive. I noticed that your package didn't support this yet, so I've worked on a patch to make it do that.

To make it work with AWS, I've added the ability to configure it like this:

```elixir
config :tirexs,
  uri: "uri",
  aws_elasticsearch: true,
  aws_access_key_id: "key",
  aws_secret_access_key: "secret",
  aws_region: "region"
```

If the `aws_elasticsearch` option is set to `true`, then this patch uses the `aws_auth` package to add Amazon's signature details to the URL. If it's not set, then this package continues on as it always has.

