### PR TITLE
Add Parameters for Bool Method

### DIFF
--- a/lib/tirexs/query.ex
+++ b/lib/tirexs/query.ex
@@ -493,8 +493,18 @@ defmodule Tirexs.Query do
   end
 
   @doc false
-  def bool(block) do
-    [bool: extract(block)]
+  def bool(options, bool_opts \\ [])
+
+  @doc false
+  def bool(options, _bool_opts) when is_list(options) do
+    bool_opts = extract_do(options, 1)
+    options = Enum.fetch!(options, 0)
+    [bool: extract(bool_opts) ++ options]
+  end
+
+  @doc false
+  def bool(options, bool_opts) do
+    [bool: extract(options) ++ bool_opts]
   end
 
   @doc false

--- a/lib/tirexs/query/logic.ex
+++ b/lib/tirexs/query/logic.ex
@@ -10,6 +10,7 @@ defmodule Tirexs.Query.Logic do
   def transpose(block) do
       case block do
         {:bool, _, [params]}                  -> Query.bool(params[:do])
+        {:bool, _, options}                   -> Query.bool(options)
         {:must, _, [params]}                  -> Query.must(params[:do])
         {:filters, _, [params]}               -> Filter.filters(params[:do])
         {:should, _, [params]}                -> Query.should(params[:do])

--- a/test/tirexs/query/bool_test.exs
+++ b/test/tirexs/query/bool_test.exs
@@ -19,6 +19,33 @@ defmodule Tirexs.Query.BoolTest do
     assert query == expected
   end
 
+  test "bool clause w/ parameters" do
+    query = query do
+      bool [minimum_should_match: 1] do
+        must do
+          match "artist", "Madonna", operator: "and"
+          match "title", "My", operator: "and"
+          match "color_tune", "red,orange"
+          match "genre", "Alternative/Indie,Christian/Gospel"
+          range "release_year", from: 1950, to: 2013
+          range "energy_mood", from: 0, to: 30
+        end
+
+        should do
+          match "genre", "Alternative/Indie,Christian/Gospel"
+          range "release_year", from: 1950, to: 2013
+        end
+
+        must_not do
+          match "genre", "Alternative/Indie,Christian/Gospel"
+        end
+      end
+    end
+
+    expected = [query: [bool: [must: [[match: [artist: [query: "Madonna", operator: "and"]]],[match: [title: [query: "My", operator: "and"]]],[match: [color_tune: [query: "red,orange"]]],[match: [genre: [query: "Alternative/Indie,Christian/Gospel"]]],[range: [release_year: [from: 1950, to: 2013]]],[range: [energy_mood: [from: 0, to: 30]]]], should: [[match: [genre: [query: "Alternative/Indie,Christian/Gospel"]]],[range: [release_year: [from: 1950, to: 2013]]]], must_not: [[match: [genre: [query: "Alternative/Indie,Christian/Gospel"]]]], minimum_should_match: 1]]]
+    assert query == expected
+  end
+
   test "bool clause w/ multiple occurrence types" do
     query = query do
       bool do


### PR DESCRIPTION
Hi there, 

I've added the possibility to add some parameters when you do a bool request. 
Like `minimum_should_match` or `boost`. 

What do you think ? 

cf: documentation: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
