### PR TITLE
Log curl commands

### DIFF
--- a/lib/tirexs/http.ex
+++ b/lib/tirexs/http.ex
@@ -335,6 +335,7 @@ defmodule Tirexs.HTTP do
   @doc false
   def request(method, request, http_options, options) do
     { :ok, _ } = :application.ensure_all_started(:tirexs)
+    Tirexs.Logger.log_command(method, request)
     :httpc.request(method, request, http_options, options)
   end
 

--- a/lib/tirexs/logger.ex
+++ b/lib/tirexs/logger.ex
@@ -1,6 +1,18 @@
 defmodule Tirexs.Logger do
   @moduledoc false
 
+  require Logger
+
+  @doc """
+  Logs all requests as CURL commands.
+  """
+  def log_command(method, request) do
+    if Tirexs.get_env(:log) do
+      method
+      |> to_curl_command(request)
+      |> Logger.debug()
+    end
+  end
 
   @doc false
   def to_curl(data) do
@@ -12,5 +24,43 @@ defmodule Tirexs.Logger do
 
   defp log(json) do
     :error_logger.info_msg(JSX.prettify!(json))
+  end
+
+  defp to_curl_command(method, {url, headers}) do
+    "curl"
+    |> put_curl_method(method)
+    |> put_curl_url(url)
+    |> put_curl_headers(headers)
+  end
+  defp to_curl_command(method, {url, headers, _content_type, []}) do
+    to_curl_command(method, {url, headers})
+  end
+  defp to_curl_command(method, {url, headers, _content_type, body}) do
+    method
+    |> to_curl_command({url, headers})
+    |> put_curl_body(body)
+  end
+
+  defp put_curl_method(curl, method) do
+    verb =
+      method
+      |> Atom.to_string()
+      |> String.upcase()
+
+    curl <> " -X#{verb}"
+  end
+
+  defp put_curl_url(curl, url) do
+    curl <> " #{url}"
+  end
+
+  defp put_curl_headers(curl, headers) do
+    Enum.reduce headers, curl, fn({key, value}, acc) ->
+      acc <> " -H '#{key}:#{value}'"
+    end
+  end
+
+  defp put_curl_body(curl, body) do
+    curl <> " -d '#{JSX.prettify!(body)}'"
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Tirexs.Mixfile do
   end
 
   def application do
-    [ applications: [:exjsx, :inets], env: env ]
+    [ applications: [:exjsx, :inets, :logger], env: env ]
   end
 
   defp env do

--- a/test/tirexs/logger_test.exs
+++ b/test/tirexs/logger_test.exs
@@ -3,10 +3,40 @@ Code.require_file "../../test_helper.exs", __ENV__.file
 defmodule Tirexs.LoggerTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureLog
+  import ExUnit.CaptureIO
+
+  @url "http://127.0.0.1/foo"
+  @headers Tirexs.HTTP.headers
+
+  setup do
+    Application.put_env(:tirexs, :log, true)
+
+    on_exit fn ->
+      Application.delete_env(:tirexs, :log)
+    end
+  end
+
   test :to_curl do
-    ExUnit.CaptureIO.capture_io(:error_logger, fn ->
+    capture_io(:error_logger, fn ->
       assert Tirexs.Logger.to_curl([d: 4]) == :ok
       assert Tirexs.Logger.to_curl(JSX.encode!([d: 4])) == :ok
     end)
+  end
+
+  test "log_command logs a curl command without a body" do
+    log = capture_log fn ->
+      Tirexs.Logger.log_command(:get, {@url, @headers})
+    end
+
+    assert log =~ ~s(curl -XGET http://127.0.0.1/foo -H 'Content-Type:application/json')
+  end
+
+  test "log_command logs a curl command with a body" do
+    log = capture_log fn ->
+      Tirexs.Logger.log_command(:get, {@url, @headers, "application/json", "{\"foo\":\"bar\"}"})
+    end
+
+    assert log =~ ~s(curl -XGET http://127.0.0.1/foo -H 'Content-Type:application/json' -d '{\n  \"foo\": \"bar\"\n}')
   end
 end


### PR DESCRIPTION
In development, it would be really handy to have CURL commands logged to the console. If a query doesn't behave the way you expect, you could just grab the CURL command and try it out.

With this PR, setting `config :tirexs, log: true` would enable this behavior.

Concerns:
+ Maybe it would be better to offer a request hooks instead? Such a feature could be useful for other scenarios as well.
+ Maybe this shouldn't be `curl`-specific? For example, it might be cool to allow users to log commands in an HTTPie format instead. Hooks would accomodate this as well.
+ Should we be using Elixir.Logger? Currently, `Tirexs.Logger.log/1` uses `:error_logger.info_msg`.