### PR TITLE
Use PUT query to update indeces settings

### DIFF
--- a/lib/tirexs/mapping.ex
+++ b/lib/tirexs/mapping.ex
@@ -96,7 +96,7 @@ defmodule Tirexs.Mapping do
     cond do
       definition[:settings] ->
         body = to_resource_json(definition)
-        HTTP.post("#{definition[:index]}", uri, body)
+        HTTP.put("#{definition[:index]}", uri, body)
       definition[:type] ->
         create_resource_settings(definition, uri)
         body = to_resource_json(definition)


### PR DESCRIPTION
Hello, I use tirexs with ElasticSearch 5.2 and I've got a trouble with `Tirexs.Mapping`. When I tried to define `mappings` with `settings`, I got an error `No handler found for uri [/my_index] and method [POST]`. 

I've checked the documentation and [found](https://www.elastic.co/guide/en/elasticsearch/reference/5.2/indices-create-index.html#mappings) that it should be a `PUT` request. However, [older](https://www.elastic.co/guide/en/elasticsearch/reference/1.4/indices-create-index.html#mappings) ES versions use `POST` request to define mappings. I tried to change `POST` request to `PUT` and it works both with ES 5.2 and ES 1.4.

In this PR `settings` request has been changed to `PUT`, to provide support for newer versions of ElasticSearch.