### PR TITLE
fixed http delete on ES5.x

### DIFF
--- a/lib/tirexs/http.ex
+++ b/lib/tirexs/http.ex
@@ -326,7 +326,7 @@ defmodule Tirexs.HTTP do
     case method do
       :get    -> ( request(method, {url, []}, [], []) |> response() )
       :head   -> ( request(method, {url, []}, [], []) |> response() )
-      :delete -> ( request(method, {url, headers, content_type, []}, [], []) |> response() )
+      :delete -> ( request(method, {url, [], content_type, []}, [], []) |> response() )
       :put    -> ( request(method, {url, headers, content_type, body}, [], options) |> response() )
       :post   -> ( request(method, {url, headers, content_type, body}, [], options) |> response() )
     end


### PR DESCRIPTION
Fixed content-type error when deleting items from ES5.5.
HTTP module acceptance test passes now when tried locally with ES2.4 and ES5.5.