### PR TITLE
Add “normalizer” macro in settings

### DIFF
--- a/lib/tirexs/index/settings.ex
+++ b/lib/tirexs/index/settings.ex
@@ -101,4 +101,13 @@ defmodule Tirexs.Index.Settings do
       var!(index) = add_index_setting(var!(index), :index, :translog, value)
     end
   end
+
+  @doc false
+  defmacro normalizer(name, value) do
+    quote do
+      var!(index) = put_index_setting(var!(index), :analysis, :normalizer)
+      [name, value] = [unquote(name), unquote(value)]
+      var!(index) = add_index_setting(var!(index), :analysis, :normalizer, Keyword.put([], to_atom(name), value))
+    end
+  end
 end


### PR DESCRIPTION
Since we can create analyzers, filters, tokenizers, etc. to settings, I thought it would be a good idead to support normalizers too.

This doesn’t break any existing feature 😄 